### PR TITLE
[catalog-server] Fix security context

### DIFF
--- a/charts/catalog-server/Chart.yaml
+++ b/charts/catalog-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.7.5"
 description: A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 name: catalog-server
-version: 0.2.2
+version: 0.2.3
 sources: ["https://github.com/RADAR-base/RADAR-Schemas/tree/master/java-sdk"]
 type: application
 home: "https://radar-base.org"

--- a/charts/catalog-server/Chart.yaml
+++ b/charts/catalog-server/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "0.7.5"
 description: A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 name: catalog-server

--- a/charts/catalog-server/README.md
+++ b/charts/catalog-server/README.md
@@ -37,7 +37,7 @@ A Helm chart for RADAR-base catalogue server. This application creates RADAR-bas
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override catalog-server.fullname template with a string (will prepend the release name) |
 | fullnameOverride | string | `""` | String to fully override catalog-server.fullname template with a string |
-| podSecurityContext | object | `{}` | Configure catalog-server pods' Security Context |
+| podSecurityContext | object | `{fsGroup: 101}` | Configure catalog-server pods' Security Context |
 | securityContext | object | `{}` | Configure Appconfig containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `9010` | catalog-server port |

--- a/charts/catalog-server/README.md
+++ b/charts/catalog-server/README.md
@@ -2,7 +2,7 @@
 
 # catalog-server
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.5](https://img.shields.io/badge/AppVersion-0.7.5-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.5](https://img.shields.io/badge/AppVersion-0.7.5-informational?style=flat-square)
 
 A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 
@@ -37,7 +37,7 @@ A Helm chart for RADAR-base catalogue server. This application creates RADAR-bas
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override catalog-server.fullname template with a string (will prepend the release name) |
 | fullnameOverride | string | `""` | String to fully override catalog-server.fullname template with a string |
-| podSecurityContext | object | `{fsGroup: 101}` | Configure catalog-server pods' Security Context |
+| podSecurityContext | object | `{"fsGroup":101}` | Configure catalog-server pods' Security Context |
 | securityContext | object | `{}` | Configure Appconfig containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `9010` | catalog-server port |

--- a/charts/catalog-server/values.yaml
+++ b/charts/catalog-server/values.yaml
@@ -23,8 +23,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 # -- Configure catalog-server pods' Security Context
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 101
 
 # -- Configure Appconfig containers' Security Context
 securityContext: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of maintainers might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Update the security context to user 101 which is needed for containers to access the volumes.

**Benefits**

The kafka-init and catalog-server container start successfully

**Possible drawbacks**
Not known

**Applicable issues**
This is required because the [dockerfile uses user 101](https://github.com/RADAR-base/RADAR-Schemas/blob/d770a8d8ebde7320b17a1a33ea5da2d8910c8f6e/Dockerfile#L66)
And if it is not the same user in the security context, the volume will not be accessible and give the following error- 

```
kubectl logs catalog-server-5f5dc645dc-nl852 -c kafka-init
rsync: [sender] opendir "/schema/conf/lost+found" failed: Permission denied (13)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1330) [sender=3.2.3]  
```

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
