### PR TITLE
Bump radar-jdbc-connector

### DIFF
--- a/charts/radar-jdbc-connector/Chart.yaml
+++ b/charts/radar-jdbc-connector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: radar-jdbc-connector
 description: A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
-version: 0.1.1
+version: 0.1.2
 engine: gotpl
 sources: ["https://github.com/RADAR-base/RADAR-JDBC-Connector"]
 deprecated: false

--- a/charts/radar-jdbc-connector/README.md
+++ b/charts/radar-jdbc-connector/README.md
@@ -2,7 +2,7 @@
 
 # radar-jdbc-connector
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
 
@@ -32,7 +32,7 @@ A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JD
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of radar-fitbit-connector replicas to deploy |
 | image.repository | string | `"radarbase/radar-jdbc-connector"` | radar-jdbc-connector image repository |
-| image.tag | string | `"latest"` | radar-jdbc-connector image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"10.3.1"` | radar-jdbc-connector image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | radar-jdbc-connector image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override radar-jdbc-connector.fullname template with a string (will prepend the release name) |

--- a/charts/radar-jdbc-connector/values.yaml
+++ b/charts/radar-jdbc-connector/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/radar-jdbc-connector
   # -- radar-jdbc-connector image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  tag: 10.3.1
   # -- radar-jdbc-connector image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Bump RADAR-JDBC-connector to version 10.3.1. See release and change info here: https://github.com/RADAR-base/RADAR-JDBC-Connector/releases/tag/v10.3.1