### PR TITLE
Certificate for MP now can be defined as a variblable instead of a file

### DIFF
--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.1"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 0.2.1
+version: 0.2.2
 engine: gotpl
 sources: ["https://github.com/RADAR-base/ManagementPortal"]
 deprecated: false

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -2,7 +2,7 @@
 
 # management-portal
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 
@@ -58,7 +58,8 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 | postgres.connection_parameters | string | `""` | additional JDBC connection parameters e.g. sslmode=verify-full |
 | postgres.user | string | `"postgres"` | postgres user |
 | postgres.password | string | `"password"` | password of the postgres user |
-| postgres.ssl.enabled | bool | `false` | set to true of the connecting to postgres using SSL |
+| postgres.ssl.enabled | bool | `false` | set to true if the connecting to postgres using SSL |
+| postgres.ssl.keystore | string | `""` | base64 encoded certificate needed to connect to the PostgreSQL |
 | postgres.ssl.keystorepassword | string | `"keystorepassword"` |  |
 | server_name | string | `"localhost"` | domain name of the server |
 | catalogue_server | string | `"catalog-server"` | Hostname of the catalogue-server |

--- a/charts/management-portal/templates/secrets-postgres-keystore.yaml
+++ b/charts/management-portal/templates/secrets-postgres-keystore.yaml
@@ -10,5 +10,5 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 type: Opaque
 data:
-  root.crt: {{ .Files.Get "files/root.crt" | b64enc | quote }}
+  root.crt: {{ .Values.postgres.keystore }}
 {{ end }}

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -114,8 +114,15 @@ postgres:
   # -- password of the postgres user
   password: password
   ssl:
-    # -- set to true of the connecting to postgres using SSL
+    # -- set to true if the connecting to postgres using SSL
     enabled: false
+    # -- base64 encoded certificate needed to connect to the PostgreSQL
+    keystore: ""
+    # With helmfile, this can be set in a production.yaml.gotmpl
+    # file by setting
+    #   keystore: {{ readFile "certificate.pem" | b64enc | quote }}
+    # or with SOPS
+    #   keystore: {{ exec "sops" (list "-d" "certificate.pem") | b64enc | quote }}
     keystorepassword: keystorepassword
 
 # -- domain name of the server


### PR DESCRIPTION
This will allow defining the SSL certificate even when the charts and helmfile are in different repos.