### PR TITLE
Recreate app-config pods after an upgrade

### DIFF
--- a/charts/app-config/Chart.yaml
+++ b/charts/app-config/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.3.3"
 description: A Helm chart for RADAR-base application config (app-config) backend service which is used as mobile app configuration engine with per-project and per-user configuration.
 name: app-config
-version: 0.2.0
+version: 0.2.1
 sources: ["https://github.com/RADAR-base/radar-app-config"]
 type: application
 home: "https://radar-base.org"

--- a/charts/app-config/README.md
+++ b/charts/app-config/README.md
@@ -2,7 +2,7 @@
 
 # app-config
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.3](https://img.shields.io/badge/AppVersion-0.3.3-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.3](https://img.shields.io/badge/AppVersion-0.3.3-informational?style=flat-square)
 
 A Helm chart for RADAR-base application config (app-config) backend service which is used as mobile app configuration engine with per-project and per-user configuration.
 

--- a/charts/app-config/templates/deployment.yaml
+++ b/charts/app-config/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
 {{ include "app-config.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "app-config.name" . }}


### PR DESCRIPTION
Right now deploying a new version of app-config to the cluster will cause the new pod to fail because it can not acquire a lock. With this change before an update all of the existing app-config pods will be deleted before creating a new pod. 
It would be ideal to not use the Recreate deployment strategy but first changes must be done to app-config allow it to acquire the lock. 

[Recreate Deployment
](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment)