### PR TITLE
[radar-s3-connector] increment version

### DIFF
--- a/charts/radar-s3-connector/Chart.yaml
+++ b/charts/radar-s3-connector/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "5.5.1"
+appVersion: "7.1.1"
 description: A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 connector with a custom data transformers. These configurations enable a sink connector. See full list of properties here https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options
 name: radar-s3-connector
-version: 0.2.2
+version: 0.2.3
 sources: ["https://github.com/RADAR-base/kafka-connect-transform-keyvalue", "https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options"]
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-s3-connector/README.md
+++ b/charts/radar-s3-connector/README.md
@@ -2,7 +2,7 @@
 
 # radar-s3-connector
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.5.1](https://img.shields.io/badge/AppVersion-5.5.1-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
 
 A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 connector with a custom data transformers. These configurations enable a sink connector. See full list of properties here https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options
 
@@ -32,7 +32,7 @@ A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 conne
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of radar-s3-connector replicas to deploy |
 | image.repository | string | `"radarbase/kafka-connect-transform-s3"` | radar-s3-connector image repository |
-| image.tag | string | `"5.5.1"` | radar-s3-connector image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"7.1.1"` | radar-s3-connector image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | radar-s3-connector image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override radar-s3-connector.fullname template with a string (will prepend the release name) |

--- a/charts/radar-s3-connector/values.yaml
+++ b/charts/radar-s3-connector/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/kafka-connect-transform-s3
   # -- radar-s3-connector image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "5.5.1"
+  tag: "7.1.1"
   # -- radar-s3-connector image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Bumps radar-s3-connector from 5.1.1 to 7.1.1. Changes since version 5.5.1:
- Bumps Confluent platform from version 5.5.1 to 7.1.1
- Bumps Confluent S3 sink connector from version 5.5.1 to 10.0.7
- Migrates from Java 8 to Java 11

Full change set is https://github.com/RADAR-base/kafka-connect-transform-keyvalue/compare/3b5527419361a364a26c072dfa41663a740a1d0c..v7.1.1.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
