### PR TITLE
[radar-rest-sources-backend] Fix MP auth URL

### DIFF
--- a/charts/radar-rest-sources-backend/Chart.yaml
+++ b/charts/radar-rest-sources-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.2.2"
 description: A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 name: radar-rest-sources-backend
-version: 0.3.3
+version: 0.3.4
 sources: ["https://github.com/RADAR-base/RADAR-Rest-Source-Auth"]
 deprecated: false
 type: application

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -2,7 +2,7 @@
 
 # radar-rest-sources-backend
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.2](https://img.shields.io/badge/AppVersion-3.2.2-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.2](https://img.shields.io/badge/AppVersion-3.2.2-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 

--- a/charts/radar-rest-sources-backend/templates/configmap.yaml
+++ b/charts/radar-rest-sources-backend/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
 
     auth:
       # Management Portal URL
-      managementPortalUrl: http://{{ .Values.managementportal_host }}:8080/managementportal/
+      managementPortalUrl: http://{{ .Values.managementportal_host }}:8080/managementportal
       # OAuth2 Client id of rest sources authorizer backend
       clientId: radar_rest_sources_auth_backend
       # OAuth2 Client Secret of rest sources authorizer backend client


### PR DESCRIPTION
Fixes MP auth URL: removes trailing slash to enhance compatibility with older versions of the backend.