### PR TITLE
[radar-gateway] Explicitly set max body size for Kafka uploads

### DIFF
--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.5.12"
 description: A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 name: radar-gateway
-version: 0.2.3
+version: 0.2.4
 sources: ["https://github.com/RADAR-base/RADAR-Gateway"]
 deprecated: false
 type: application

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -2,7 +2,7 @@
 
 # radar-gateway
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.12](https://img.shields.io/badge/AppVersion-0.5.12-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.12](https://img.shields.io/badge/AppVersion-0.5.12-informational?style=flat-square)
 
 A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -59,6 +59,8 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | adminProperties | object | `{}` | Additional Kafka Admin Client settings as key value pairs. Read from https://kafka.apache.org/documentation/#adminclientconfigs. |
 | producerProperties | object | `{"compression.type":"lz4"}` | Kafka producer properties as key value pairs. Read from https://kafka.apache.org/documentation/#producerconfigs. |
 | serializationProperties | object | `{}` | Additional Kafka serialization settings, used in KafkaAvroSerializer. Read from [io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig]. |
+| serverProperties | object | `{"maxRequestSize":25165824}` | Additional gateway server properties |
+| serverProperties.maxRequestSize | int | `25165824` | Maximum request size, also after decompression. |
 | cc.enabled | bool | `false` | set to true, if requests should be forwarded to Confluent Cloud based brokers. |
 | cc.apiKey | string | `"ccApikey"` | Confluent Cloud cluster API key |
 | cc.apiSecret | string | `"ccApiSecret"` | Confluent Cloud cluster API secret |

--- a/charts/radar-gateway/templates/configmap.yaml
+++ b/charts/radar-gateway/templates/configmap.yaml
@@ -20,6 +20,9 @@ data:
 
     server:
       baseUri: http://0.0.0.0:{{ .Values.service.port }}/kafka/
+      {{- range $key, $value := .Values.serverProperties }}
+      {{ $key }}: {{ $value }}
+      {{- end }}
 
     kafka:
       producer:

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -51,6 +51,7 @@ ingress:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /kafka/$1
+    nginx.ingress.kubernetes.io/proxy-body-size: 24m
   # -- Path within the url structure
   path: "/kafka/?(.*)"
   pathType: ImplementationSpecific

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -107,6 +107,11 @@ producerProperties:
 # -- Additional Kafka serialization settings, used in KafkaAvroSerializer. Read from [io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig].
 serializationProperties: {}
 
+# -- Additional gateway server properties
+serverProperties:
+  # -- Maximum request size, also after decompression.
+  maxRequestSize: 25165824
+
 cc:
   # -- set to true, if requests should be forwarded to Confluent Cloud based brokers.
   enabled: false


### PR DESCRIPTION
**Description of the change**

In the radar-gateway ingress, match the max body size with the default max body size internally in radar-gateway. This avoids _413  Request Entity Too Large_ HTTP responses for data that could well be accepted by the gateway.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
