### PR TITLE
[radar-output] Update radar-output to 2.2.0

### DIFF
--- a/charts/radar-output/Chart.yaml
+++ b/charts/radar-output/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "2.0.1"
+appVersion: "2.2.0"
 description: A Helm chart for RADAR-base output restructure service. This application reads data from intermediate storage and restructure the data into project-> subject-id-> data topic -> data split per hour. This service offers few options to choose the source and target of the pipeline.
 name: radar-output
-version: 0.2.1
+version: 0.3.0
 sources: ["https://github.com/RADAR-base/radar-output-restructure"]
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-output/README.md
+++ b/charts/radar-output/README.md
@@ -2,7 +2,7 @@
 
 # radar-output
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.1](https://img.shields.io/badge/AppVersion-2.0.1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 A Helm chart for RADAR-base output restructure service. This application reads data from intermediate storage and restructure the data into project-> subject-id-> data topic -> data split per hour. This service offers few options to choose the source and target of the pipeline.
 
@@ -31,7 +31,7 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of radar-output replicas to deploy |
 | image.repository | string | `"radarbase/radar-output-restructure"` | radar-output image repository |
-| image.tag | string | `"2.0.1"` | radar-output image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"2.2.0"` | radar-output image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | radar-output image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override radar-output.fullname template with a string (will prepend the release name) |
@@ -39,15 +39,19 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 | podSecurityContext | object | `{}` | Configure radar-output pods' Security Context |
 | securityContext | object | `{}` | Configure radar-output containers' Security Context |
 | resources.limits | object | `{"cpu":"1000m"}` | CPU/Memory resource limits |
-| resources.requests | object | `{"cpu":"100m","memory":"400Mi"}` | CPU/Memory resource requests |
+| resources.requests | object | `{"cpu":"100m","memory":"2Gi"}` | CPU/Memory resource requests |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | tolerations | list | `[]` | Toleration labels for pod assignment |
 | affinity | object | `{}` | Affinity labels for pod assignment |
+| javaOpts | string | `"-Xms400m -Xmx3g"` |  |
 | source.type | string | `"s3"` | Type of the intermediate storage of the RADAR-base pipeline e.g. s3, hdfs |
 | source.s3.endpoint | string | `"http://minio:9000"` | s3 endpoint of the intermediate storage |
 | source.s3.accessToken | string | `"access_key"` | s3 access-key of the intermediate storage |
 | source.s3.secretKey | string | `"secret"` | s3 secret-key of the intermediate storage |
 | source.s3.bucket | string | `"radar-intermediate-storage"` | s3 bucket name of the intermediate storage |
+| source.s3.connectTimeout | string | `nil` | s3 HTTP connect timeout in seconds |
+| source.s3.writeTimeout | string | `nil` | s3 HTTP write timeout in seconds |
+| source.s3.readTimeout | string | `nil` | s3 HTTP read timeout in seconds |
 | source.azure.endpoint | string | `""` | Azure endpoint of the intermediate storage |
 | source.azure.username | string | `""` | Azure username to access the s3 endpoint when using personal login |
 | source.azure.password | string | `""` | Azure password when using personal login |
@@ -55,11 +59,18 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 | source.azure.accountKey | string | `""` | Azure account key when using shared access tokens |
 | source.azure.sasToken | string | `""` | Azure SAS(shared access signature) token when using shared access tokens |
 | source.azure.container | string | `""` | Azure blob container name |
+| source.azure.connectTimeout | string | `nil` | Azure HTTP connect timeout in seconds |
+| source.azure.responseTimeout | string | `nil` | Azure HTTP response timeout in seconds |
+| source.azure.writeTimeout | string | `nil` | Azure HTTP write timeout in seconds |
+| source.azure.readTimeout | string | `nil` | Azure HTTP read timeout in seconds |
 | target.type | string | `"s3"` | Type of the output storage of the RADAR-base pipeline e.g. s3, local |
 | target.s3.endpoint | string | `"http://minio:9000"` | s3 endpoint of the output storage |
 | target.s3.accessToken | string | `"access_key"` | s3 access-key of the output storage |
 | target.s3.secretKey | string | `"secret"` | s3 secret-key of the output storage |
 | target.s3.bucket | string | `"radar-output-storage"` | s3 bucket name of the output storage |
+| target.s3.connectTimeout | string | `nil` | s3 HTTP connect timeout in seconds |
+| target.s3.writeTimeout | string | `nil` | s3 HTTP write timeout in seconds |
+| target.s3.readTimeout | string | `nil` | s3 HTTP read timeout in seconds |
 | target.azure.endpoint | string | `""` | Azure endpoint of the output storage |
 | target.azure.username | string | `""` | Azure username to access the s3 endpoint when using personal login |
 | target.azure.password | string | `""` | Azure password when using personal login |
@@ -67,11 +78,18 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 | target.azure.accountKey | string | `""` | Azure account key when using shared access tokens |
 | target.azure.sasToken | string | `""` | Azure SAS(shared access signature) token when using shared access tokens |
 | target.azure.container | string | `""` | Azure blob container name |
+| target.azure.connectTimeout | string | `nil` | Azure HTTP connect timeout in seconds |
+| target.azure.responseTimeout | string | `nil` | Azure HTTP response timeout in seconds |
+| target.azure.writeTimeout | string | `nil` | Azure HTTP write timeout in seconds |
+| target.azure.readTimeout | string | `nil` | Azure HTTP read timeout in seconds |
 | redis.uri | string | `"redis://redis-master:6379"` | URL of the redis database |
+| worker.cacheSize | int | `300` | Maximum number of files and converters to keep open while processing |
+| worker.cacheOffsetsSize | int | `500000` | Maximum number of offsets in cache. |
 | worker.minimumFileAge | int | `900` | Minimum amount of time in seconds since a file was last modified for it to be considered for processing. |
 | worker.numThreads | int | `2` | Number of threads to do processing on |
 | cleaner.age | int | `7` | Number of days after which a source file is considered old |
 | paths.input | string | `"topics"` | Relative path to intermediate storage root to browse for data |
 | paths.output | string | `"output"` | Relative path to output storage to write data |
-| paths.factory | string | `"org.radarbase.output.path.ObservationKeyPathFactory"` | # Output path construction factory |
+| paths.factory | string | `"org.radarbase.output.path.FormattedPathFactory"` | Output path construction factory |
 | paths.properties | object | `{}` | Additional properties. For details see https://github.com/RADAR-base/radar-output-restructure/blob/master/restructure.yml |
+| topics | object | `{}` | Individual topic configuration |

--- a/charts/radar-output/templates/configmap-restructure.yaml
+++ b/charts/radar-output/templates/configmap-restructure.yaml
@@ -23,6 +23,9 @@ data:
         accessToken: "{{ .Values.source.s3.accessToken }}"
         secretKey: "{{ .Values.source.s3.secretKey }}"
         bucket: "{{ .Values.source.s3.bucket }}"
+        connectTimeout: {{ .Values.source.s3.connectTimeout }}
+        writeTimeout: {{ .Values.source.s3.writeTimeout }}
+        readTimeout: {{ .Values.source.s3.readTimeout }}
       azure:
         endpoint: "{{ .Values.source.azure.endpoint }}"
         username: "{{ .Values.source.azure.username }}"
@@ -31,6 +34,10 @@ data:
         accountKey: "{{ .Values.source.azure.accountKey }}"
         sasToken: "{{ .Values.source.azure.sasToken }}"
         container: "{{ .Values.source.azure.container }}"
+        connectTimeout: {{ .Values.source.azure.connectTimeout }}
+        responseTimeout: {{ .Values.source.azure.responseTimeout }}
+        writeTimeout: {{ .Values.source.azure.writeTimeout }}
+        readTimeout: {{ .Values.source.azure.readTimeout }}
 
     target:
       type: "{{ .Values.target.type }}"
@@ -39,6 +46,9 @@ data:
         accessToken: "{{ .Values.target.s3.accessToken }}"
         secretKey: "{{ .Values.target.s3.secretKey }}"
         bucket: "{{ .Values.target.s3.bucket }}"
+        connectTimeout: {{ .Values.target.s3.connectTimeout }}
+        writeTimeout: {{ .Values.target.s3.writeTimeout }}
+        readTimeout: {{ .Values.target.s3.readTimeout }}
       azure:
         endpoint: "{{ .Values.target.azure.endpoint }}"
         username: "{{ .Values.target.azure.username }}"
@@ -47,6 +57,10 @@ data:
         accountKey: "{{ .Values.target.azure.accountKey }}"
         sasToken: "{{ .Values.target.azure.sasToken }}"
         container: "{{ .Values.target.azure.container }}"
+        connectTimeout: {{ .Values.target.azure.connectTimeout }}
+        responseTimeout: {{ .Values.target.azure.responseTimeout }}
+        writeTimeout: {{ .Values.target.azure.writeTimeout }}
+        readTimeout: {{ .Values.target.azure.readTimeout }}
 
     redis:
       uri: "{{ .Values.redis.uri }}"
@@ -81,9 +95,9 @@ data:
     # Worker settings
     worker:
       # Maximum number of files and converters to keep open while processing
-      cacheSize: 300
+      cacheSize: {{ .Values.worker.cacheSize }}
       # Maximum number of offsets in cache.
-      cacheOffsetsSize: 500000
+      cacheOffsetsSize: {{ .Values.worker.cacheOffsetsSize }}
       # Number of threads to do processing with
       numThreads: "{{ .Values.worker.numThreads }}"
       # Maximum number of files to process in any given topic.
@@ -120,17 +134,9 @@ data:
         {{ .Values.paths.properties | toYaml | indent 8 | trim }}
 
     # Individual topic configuration
+    {{- if .Values.topics }}
+    topics:
+      {{ .Values.topics | toYaml | indent 6 | trim }}
+    {{- else }}
     topics: {}
-    #  # topic name
-    #  connect_fitbit_source:
-    #    # deduplicate this topic, regardless of the format settings
-    #    deduplication:
-    #      # deduplicate this topic only using given fields.
-    #      distinctFields: [value.time]
-    #  connect_fitbit_bad:
-    #    # Do not process this topic
-    #    exclude: true
-    #  biovotion_acceleration:
-    #    # Disable deduplication
-    #    deduplication:
-    #      enable: false
+    {{- end }}

--- a/charts/radar-output/templates/deployment.yaml
+++ b/charts/radar-output/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - -S
           env:
           - name: RADAR_HDFS_RESTRUCTURE_OPTS
-            value: "-Xms400m -Xmx3g"
+            value: {{ .Values.javaOpts  | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/radar-output/values.yaml
+++ b/charts/radar-output/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/radar-output-restructure
   # -- radar-output image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 2.0.1
+  tag: 2.2.0
   # -- radar-output image pull policy
   pullPolicy: IfNotPresent
 
@@ -47,7 +47,7 @@ resources:
   # -- CPU/Memory resource requests
   requests:
     cpu: 100m
-    memory: 400Mi
+    memory: 2Gi
 
 # -- Node labels for pod assignment
 nodeSelector: {}
@@ -57,6 +57,8 @@ tolerations: []
 
 # -- Affinity labels for pod assignment
 affinity: {}
+
+javaOpts: "-Xms400m -Xmx3g"
 
 source:
   # -- Type of the intermediate storage of the RADAR-base pipeline e.g. s3, hdfs
@@ -70,6 +72,12 @@ source:
     secretKey: secret
     # -- s3 bucket name of the intermediate storage
     bucket: radar-intermediate-storage
+    # -- s3 HTTP connect timeout in seconds
+    connectTimeout:
+    # -- s3 HTTP write timeout in seconds
+    writeTimeout:
+    # -- s3 HTTP read timeout in seconds
+    readTimeout:
   azure:
     # -- Azure endpoint of the intermediate storage
     endpoint: ""
@@ -85,6 +93,14 @@ source:
     sasToken: ""
     # -- Azure blob container name
     container: ""
+    # -- Azure HTTP connect timeout in seconds
+    connectTimeout:
+    # -- Azure HTTP response timeout in seconds
+    responseTimeout:
+    # -- Azure HTTP write timeout in seconds
+    writeTimeout:
+    # -- Azure HTTP read timeout in seconds
+    readTimeout:
 
 target:
   # -- Type of the output storage of the RADAR-base pipeline e.g. s3, local
@@ -98,6 +114,12 @@ target:
     secretKey: secret
     # -- s3 bucket name of the output storage
     bucket: radar-output-storage
+    # -- s3 HTTP connect timeout in seconds
+    connectTimeout:
+    # -- s3 HTTP write timeout in seconds
+    writeTimeout:
+    # -- s3 HTTP read timeout in seconds
+    readTimeout:
   azure:
     # -- Azure endpoint of the output storage
     endpoint: ""
@@ -113,12 +135,24 @@ target:
     sasToken: ""
     # -- Azure blob container name
     container: ""
+    # -- Azure HTTP connect timeout in seconds
+    connectTimeout:
+    # -- Azure HTTP response timeout in seconds
+    responseTimeout:
+    # -- Azure HTTP write timeout in seconds
+    writeTimeout:
+    # -- Azure HTTP read timeout in seconds
+    readTimeout:
 
 redis:
   # -- URL of the redis database
   uri: redis://redis-master:6379
 
 worker:
+  # -- Maximum number of files and converters to keep open while processing
+  cacheSize: 300
+  # -- Maximum number of offsets in cache.
+  cacheOffsetsSize: 500000
   # -- Minimum amount of time in seconds since a file was last modified for it to be considered for processing.
   minimumFileAge: 900
   # -- Number of threads to do processing on
@@ -133,7 +167,23 @@ paths:
   input: topics
   # -- Relative path to output storage to write data
   output: output
-  # -- # Output path construction factory
-  factory: org.radarbase.output.path.ObservationKeyPathFactory
+  # -- Output path construction factory
+  factory: org.radarbase.output.path.FormattedPathFactory
   # -- Additional properties. For details see https://github.com/RADAR-base/radar-output-restructure/blob/master/restructure.yml
   properties: {}
+
+# -- Individual topic configuration
+topics: {}
+  #  # topic name
+  #  connect_fitbit_source:
+  #    # deduplicate this topic, regardless of the format settings
+  #    deduplication:
+  #      # deduplicate this topic only using given fields.
+  #      distinctFields: [value.time]
+  #  connect_fitbit_bad:
+  #    # Do not process this topic
+  #    exclude: true
+  #  biovotion_acceleration:
+  #    # Disable deduplication
+  #    deduplication:
+  #      enable: false


### PR DESCRIPTION
Updates radar-output from version 2.0.1 to 2.2.0. This version has more efficient parallelism, fewer vulnerabilities, and fixes some OkHttp connection leaks. Includes configurability for javaOpts, individual topics, and source and target HTTP timeouts.

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
