### PR TITLE
[radar-jdbc-connector] Update radar jdbc connector version and config

### DIFF
--- a/charts/radar-jdbc-connector/Chart.yaml
+++ b/charts/radar-jdbc-connector/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "10.3.2"
+appVersion: "10.5.2"
 name: radar-jdbc-connector
 description: A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
-version: 0.1.6
+version: 0.2.0
 engine: gotpl
 sources: ["https://github.com/RADAR-base/RADAR-JDBC-Connector"]
 deprecated: false

--- a/charts/radar-jdbc-connector/README.md
+++ b/charts/radar-jdbc-connector/README.md
@@ -2,7 +2,7 @@
 
 # radar-jdbc-connector
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3.2](https://img.shields.io/badge/AppVersion-10.3.2-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.5.2](https://img.shields.io/badge/AppVersion-10.5.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
 
@@ -30,9 +30,9 @@ A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JD
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| replicaCount | int | `1` | Number of radar-fitbit-connector replicas to deploy |
+| replicaCount | int | `1` | Number of radar-jdbc-connector replicas to deploy |
 | image.repository | string | `"radarbase/radar-jdbc-connector"` | radar-jdbc-connector image repository |
-| image.tag | string | `"10.3.2"` | radar-jdbc-connector image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"10.5.2"` | radar-jdbc-connector image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | radar-jdbc-connector image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override radar-jdbc-connector.fullname template with a string (will prepend the release name) |
@@ -45,14 +45,26 @@ A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JD
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | tolerations | list | `[]` | Toleration labels for pod assignment |
 | affinity | object | `{}` | Affinity labels for pod assignment |
-| zookeeper | string | `"cp-zookeeper-headless:2181"` | URI of Zookeeper instances of the cluster |
 | kafka | string | `"PLAINTEXT://cp-kafka-headless:9092"` | URI of Kafka brokers of the cluster |
 | kafka_num_brokers | string | `"3"` | Number of Kafka brokers. This is used to validate the cluster availability at connector init. |
 | schema_registry | string | `"http://cp-schema-registry:8081"` | URL of the Kafka schema registry |
-| topics | string | `"android_phone_relative_location, android_phone_battery_level, connect_upload_altoida_summary, connect_fitbit_intraday_heart_rate, connect_fitbit_intraday_steps"` | Comma-separated list of topics the connector will read from and ingest into the database |
+| maxTasks | int | `2` | Maximum number of worker threads inside a connector pod. |
+| mode | string | `"sink"` | Either source or sink |
+| source.name | string | `"radar-jdbc-source"` | Name of the connector Kafka producer group |
+| source.tableWhitelist | string | `""` | Comma-separted list of tables to read |
+| source.topicPrefix | string | `""` | Prefix to prepend to table names to generate the name of the Kafka topic to publish data to. |
+| source.mode | string | `"incrementing"` | How to detect new values in a table. |
+| source.incrementingColumnName | string | `""` | When using mode incrementing, which column to use as incrementing. If empty, autodetection will be used. |
+| sink.name | string | `"radar-jdbc-sink"` | Name of the connector Kafka consumer group |
+| sink.autoCreate | bool | `true` | create table if it does not exist |
+| sink.insertMode | string | `"upsert"` | How to insert new values into the database |
+| sink.primaryKeys.mode | string | `"record_value"` |  |
+| sink.primaryKeys.fields | list | `["time","userId","projectId"]` | fields to include as primary keys when creating the table |
+| sink.topics | string | `"android_phone_relative_location, android_phone_battery_level, connect_upload_altoida_summary, connect_fitbit_intraday_heart_rate, connect_fitbit_intraday_steps"` | Comma-separated list of topics the connector will read from and ingest into the database |
+| sink.tableNameFormat | string | `"${topic}"` | How to format a table name based on the inserted topic |
 | environment | object | `{"CONNECT_SECURITY_PROTOCOL":"PLAINTEXT"}` | Additional environment variables to pass to the connector. These can be used to pass supported kafka and connect specifc [configs](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#kconnect-long-configuration) |
 | environment.CONNECT_SECURITY_PROTOCOL | string | `"PLAINTEXT"` | Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL. |
-| timescaledb.host | string | `"timescaledb-postgresql-headless"` | Host of the TimescaleDB database |
-| timescaledb.username | string | `"grafana"` | TimescaleDB database username |
-| timescaledb.password | string | `"password"` | TimescaleDB database password |
-| timescaledb.database_name | string | `"grafana-metrics"` | TimescaleDB database name |
+| jdbc.url | string | `"jdbc:postgresql://timescaledb-postgresql-headless:5432/grafana-metrics"` | Host of the TimescaleDB database |
+| jdbc.user | string | `"grafana"` | TimescaleDB database username |
+| jdbc.password | string | `"password"` | TimescaleDB database password |
+| jdbc.dialect | string | `"TimescaleDBDatabaseDialect"` | JDBC connect dialect that the database uses |

--- a/charts/radar-jdbc-connector/README.md
+++ b/charts/radar-jdbc-connector/README.md
@@ -58,7 +58,7 @@ A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JD
 | sink.name | string | `"radar-jdbc-sink"` | Name of the connector Kafka consumer group |
 | sink.autoCreate | bool | `true` | create table if it does not exist |
 | sink.insertMode | string | `"upsert"` | How to insert new values into the database |
-| sink.primaryKeys.mode | string | `"record_value"` |  |
+| sink.primaryKeys.mode | string | `"record_value"` | where to read the primary keys from when creating the table |
 | sink.primaryKeys.fields | list | `["time","userId","projectId"]` | fields to include as primary keys when creating the table |
 | sink.topics | string | `"android_phone_relative_location, android_phone_battery_level, connect_upload_altoida_summary, connect_fitbit_intraday_heart_rate, connect_fitbit_intraday_steps"` | Comma-separated list of topics the connector will read from and ingest into the database |
 | sink.tableNameFormat | string | `"${topic}"` | How to format a table name based on the inserted topic |

--- a/charts/radar-jdbc-connector/templates/_helpers.tpl
+++ b/charts/radar-jdbc-connector/templates/_helpers.tpl
@@ -50,3 +50,9 @@ Selector labels
 app.kubernetes.io/name: {{ include "radar-jdbc-connector.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{- define "radar-jdbc-connector.validateValues" -}}
+{{- if not (has .Values.mode (list "sink" "source")) }}
+{{- fail "Mode must be 'source' for JDBC source connector or 'sink' for JDBC sink connector."}}
+{{- end -}}
+{{- end -}}

--- a/charts/radar-jdbc-connector/templates/configmap.yaml
+++ b/charts/radar-jdbc-connector/templates/configmap.yaml
@@ -1,3 +1,5 @@
+{{- include "radar-jdbc-connector.validateValues" . }}
+{{ $name := ternary  .Values.sink.name .Values.source.name (eq .Values.mode "sink") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,34 +8,55 @@ metadata:
     {{- include "radar-jdbc-connector.labels" . | nindent 4 }}
 data:
   sink-timescale.properties: |
-    # Kafka consumer configuration
-    name = radar-timescale-sink
     # Kafka connector configuration
-    connector.class = io.confluent.connect.jdbc.JdbcSinkConnector
-    tasks.max = 2
-    transforms=mergeKey,timestamp
-    transforms.mergeKey.type=org.radarbase.kafka.connect.transforms.MergeKey
-    transforms.timestamp.type=org.radarbase.kafka.connect.transforms.TimestampConverter
-    transforms.timestamp.fields=time,timeReceived,timeCompleted,timestamp
-    # Topics that will be consumed
-    topics = {{ .Values.topics }}
-    connection.url=jdbc:postgresql://{{ .Values.timescaledb.host }}/{{ .Values.timescaledb.database_name }}
-    connection.user={{ .Values.timescaledb.username }}
-    connection.password={{ .Values.timescaledb.password }}
-    dialect.name = TimescaleDBDatabaseDialect
-    insert.mode = upsert
-    pk.mode = record_value
-    pk.fields = time, userId, projectId
-    auto.create = true
+    name = {{ $name }}
+
+    tasks.max = {{ .Values.maxTasks }}
+
+    # General connection parameters
+    connection.url={{ .Values.jdbc.url }}
+    connection.user={{ .Values.jdbc.user }}
+    connection.password={{ .Values.jdbc.password }}
+    dialect.name = {{ .Values.jdbc.dialect }}
     max.retries = 15
     # Wait 10 minutes before retrying failed task
     retry.backoff.ms = 600000
     connection.attempts = 15
     # Wait 10 minutes before attempting connection 
     connection.backoff.ms = 600000
+
+    {{- if eq .Values.mode "sink" }}
+    {{- with .Values.sink }}
+    # Kafka connector configuration
+    connector.class = io.confluent.connect.jdbc.JdbcSinkConnector
+    insert.mode = {{ .insertMode }}
+    # Topics that will be consumed
+    topics = {{ .topics }}
+    table.name.format = {{ .tableNameFormat }}
+    auto.create = {{ .enabled }}
+    {{- with .primaryKeys }}
+    pk.mode = {{ .mode }}
+    pk.fields = {{ join ", " .fields }}
+    {{- end }}
+    transforms=mergeKey,timestamp
+    transforms.mergeKey.type=org.radarbase.kafka.connect.transforms.MergeKey
+    transforms.timestamp.type=org.radarbase.kafka.connect.transforms.TimestampConverter
+    transforms.timestamp.fields=time,timeReceived,timeCompleted,timestamp
+    {{- end }}
+    {{- end }}
+    {{- if eq .Values.mode "source" }}
+    {{- with .Values.source }}
+    # Kafka connector configuration
+    connector.class = io.confluent.connect.jdbc.JdbcSourceConnector
+    table.whitelist = {{ .tableWhitelist }}
+    topic.prefix = {{ .topicPrefix }}
+    mode = {{ .mode }}
+    incrementing.column.name = {{ .incrementingColumnName }}
+    {{- end }}
+    {{- end }}
   healthcheck.sh: |
     #!/bin/sh
-    STATUS=$(curl -sf localhost:8083/connectors/radar-timescale-sink/status | grep -o '\"state\":\"[^\"]*\"')
+    STATUS=$(curl -sf localhost:8083/connectors/{{ $name }}/status | grep -o '\"state\":\"[^\"]*\"')
     if echo "$STATUS" | tr '\\n' ',' | grep -q FAILED; then
       exit 1
     elif [ $(echo "$STATUS" | grep RUNNING | wc -l) -le 1 ]; then

--- a/charts/radar-jdbc-connector/templates/configmap.yaml
+++ b/charts/radar-jdbc-connector/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
     # Wait 10 minutes before retrying failed task
     retry.backoff.ms = 600000
     connection.attempts = 15
-    # Wait 10 minutes before attempting connection 
+    # Wait 10 minutes before attempting connection
     connection.backoff.ms = 600000
 
     {{- if eq .Values.mode "sink" }}
@@ -33,7 +33,7 @@ data:
     # Topics that will be consumed
     topics = {{ .topics }}
     table.name.format = {{ .tableNameFormat }}
-    auto.create = {{ .enabled }}
+    auto.create = {{ .autoCreate }}
     {{- with .primaryKeys }}
     pk.mode = {{ .mode }}
     pk.fields = {{ join ", " .fields }}

--- a/charts/radar-jdbc-connector/templates/deployment.yaml
+++ b/charts/radar-jdbc-connector/templates/deployment.yaml
@@ -71,10 +71,6 @@ spec:
             value: "{{ .Values.schema_registry }}"
           - name: CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
             value: "{{ .Values.schema_registry }}"
-          - name: CONNECT_INTERNAL_KEY_CONVERTER
-            value: "org.apache.kafka.connect.json.JsonConverter"
-          - name: CONNECT_INTERNAL_VALUE_CONVERTER
-            value: "org.apache.kafka.connect.json.JsonConverter"
           - name: CONNECT_OFFSET_STORAGE_FILE_FILENAME
             value: "/var/lib/kafka-connect-jdbc/logs/connect.offsets"
           - name: CONNECT_REST_ADVERTISED_HOST_NAME
@@ -92,7 +88,7 @@ spec:
           - name: CONNECT_PLUGIN_PATH
             value: /usr/share/kafka-connect/plugins
           - name: CONNECT_LOG4J_ROOT_LOGLEVEL
-            value: WARN
+            value: INFO
           - name: KAFKA_BROKERS
             value: "{{ .Values.kafka_num_brokers }}"
           - name: CONNECT_LOG4J_LOGGERS

--- a/charts/radar-jdbc-connector/values.yaml
+++ b/charts/radar-jdbc-connector/values.yaml
@@ -97,7 +97,7 @@ sink:
   # -- How to insert new values into the database
   insertMode: upsert
   primaryKeys:
-    #-- where to read the primary keys from when creating the table
+    # -- where to read the primary keys from when creating the table
     mode: record_value
     # -- fields to include as primary keys when creating the table
     fields:

--- a/charts/radar-jdbc-connector/values.yaml
+++ b/charts/radar-jdbc-connector/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# -- Number of radar-fitbit-connector replicas to deploy
+# -- Number of radar-jdbc-connector replicas to deploy
 replicaCount: 1
 
 image:
@@ -10,7 +10,7 @@ image:
   repository: radarbase/radar-jdbc-connector
   # -- radar-jdbc-connector image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: dev
+  tag: 10.5.2
   # -- radar-jdbc-connector image pull policy
   pullPolicy: IfNotPresent
 
@@ -71,6 +71,7 @@ kafka_num_brokers: "3"
 # -- URL of the Kafka schema registry
 schema_registry: http://cp-schema-registry:8081
 
+# -- Maximum number of worker threads inside a connector pod.
 maxTasks: 2
 
 # -- Either source or sink
@@ -83,9 +84,9 @@ source:
   tableWhitelist: ""
   # -- Prefix to prepend to table names to generate the name of the Kafka topic to publish data to.
   topicPrefix: ""
-  # -- How to detect new values
+  # -- How to detect new values in a table.
   mode: incrementing
-  # -- When using mode incrementing, which colum to use as incrementing. If empty, autodetection will be used.
+  # -- When using mode incrementing, which column to use as incrementing. If empty, autodetection will be used.
   incrementingColumnName: ""
 
 sink:
@@ -98,13 +99,14 @@ sink:
   primaryKeys:
     #-- where to read the primary keys from when creating the table
     mode: record_value
-    #-- fields to include as primary keys when creating the table
+    # -- fields to include as primary keys when creating the table
     fields:
       - time
       - userId
       - projectId
   # -- Comma-separated list of topics the connector will read from and ingest into the database
   topics: android_phone_relative_location, android_phone_battery_level, connect_upload_altoida_summary, connect_fitbit_intraday_heart_rate, connect_fitbit_intraday_steps
+  # -- How to format a table name based on the inserted topic
   tableNameFormat: "${topic}"
 
 # -- Additional environment variables to pass to the connector. These can be used to pass supported kafka and connect specifc [configs](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#kconnect-long-configuration)
@@ -119,4 +121,5 @@ jdbc:
   user: grafana
   # -- TimescaleDB database password
   password: password
+  # -- JDBC connect dialect that the database uses
   dialect: TimescaleDBDatabaseDialect

--- a/charts/radar-jdbc-connector/values.yaml
+++ b/charts/radar-jdbc-connector/values.yaml
@@ -93,6 +93,8 @@ sink:
   name: radar-jdbc-sink
   # -- create table if it does not exist
   autoCreate: true
+  # -- How to insert new values into the database
+  insertMode: upsert
   primaryKeys:
     #-- where to read the primary keys from when creating the table
     mode: record_value

--- a/charts/radar-jdbc-connector/values.yaml
+++ b/charts/radar-jdbc-connector/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/radar-jdbc-connector
   # -- radar-jdbc-connector image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 10.3.2
+  tag: dev
   # -- radar-jdbc-connector image pull policy
   pullPolicy: IfNotPresent
 
@@ -64,27 +64,57 @@ tolerations: []
 # -- Affinity labels for pod assignment
 affinity: {}
 
-# -- URI of Zookeeper instances of the cluster
-zookeeper: cp-zookeeper-headless:2181
 # -- URI of Kafka brokers of the cluster
 kafka: PLAINTEXT://cp-kafka-headless:9092
 # -- Number of Kafka brokers. This is used to validate the cluster availability at connector init.
 kafka_num_brokers: "3"
 # -- URL of the Kafka schema registry
 schema_registry: http://cp-schema-registry:8081
-# -- Comma-separated list of topics the connector will read from and ingest into the database
-topics: android_phone_relative_location, android_phone_battery_level, connect_upload_altoida_summary, connect_fitbit_intraday_heart_rate, connect_fitbit_intraday_steps
+
+maxTasks: 2
+
+# -- Either source or sink
+mode: sink
+
+source:
+  # -- Name of the connector Kafka producer group
+  name: radar-jdbc-source
+  # -- Comma-separted list of tables to read
+  tableWhitelist: ""
+  # -- Prefix to prepend to table names to generate the name of the Kafka topic to publish data to.
+  topicPrefix: ""
+  # -- How to detect new values
+  mode: incrementing
+  # -- When using mode incrementing, which colum to use as incrementing. If empty, autodetection will be used.
+  incrementingColumnName: ""
+
+sink:
+  # -- Name of the connector Kafka consumer group
+  name: radar-jdbc-sink
+  # -- create table if it does not exist
+  autoCreate: true
+  primaryKeys:
+    #-- where to read the primary keys from when creating the table
+    mode: record_value
+    #-- fields to include as primary keys when creating the table
+    fields:
+      - time
+      - userId
+      - projectId
+  # -- Comma-separated list of topics the connector will read from and ingest into the database
+  topics: android_phone_relative_location, android_phone_battery_level, connect_upload_altoida_summary, connect_fitbit_intraday_heart_rate, connect_fitbit_intraday_steps
+  tableNameFormat: "${topic}"
+
 # -- Additional environment variables to pass to the connector. These can be used to pass supported kafka and connect specifc [configs](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#kconnect-long-configuration)
 environment:
   # -- Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
   CONNECT_SECURITY_PROTOCOL: PLAINTEXT
 
-timescaledb:
+jdbc:
   # -- Host of the TimescaleDB database
-  host: timescaledb-postgresql-headless
+  url: jdbc:postgresql://timescaledb-postgresql-headless:5432/grafana-metrics
   # -- TimescaleDB database username
-  username: grafana
+  user: grafana
   # -- TimescaleDB database password
   password: password
-  # -- TimescaleDB database name
-  database_name: grafana-metrics
+  dialect: TimescaleDBDatabaseDialect


### PR DESCRIPTION
- adds support for both JDBC source and sink connectors
- make JDBC configuration in line with other helm charts

This change is not completely backwards compatible with older radar-jdbc-connector charts, so any deployments that use it should update their configuration.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
