### PR TITLE
[radar-jdbc-connector] Add source connector properties

### DIFF
--- a/charts/radar-jdbc-connector/Chart.yaml
+++ b/charts/radar-jdbc-connector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.5.2"
 name: radar-jdbc-connector
 description: A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
-version: 0.2.0
+version: 0.2.1
 engine: gotpl
 sources: ["https://github.com/RADAR-base/RADAR-JDBC-Connector"]
 deprecated: false

--- a/charts/radar-jdbc-connector/Chart.yaml
+++ b/charts/radar-jdbc-connector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.5.2"
 name: radar-jdbc-connector
 description: A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
-version: 0.2.1
+version: 0.3.0
 engine: gotpl
 sources: ["https://github.com/RADAR-base/RADAR-JDBC-Connector"]
 deprecated: false

--- a/charts/radar-jdbc-connector/README.md
+++ b/charts/radar-jdbc-connector/README.md
@@ -2,7 +2,7 @@
 
 # radar-jdbc-connector
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.5.2](https://img.shields.io/badge/AppVersion-10.5.2-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.5.2](https://img.shields.io/badge/AppVersion-10.5.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
 
@@ -50,6 +50,9 @@ A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JD
 | schema_registry | string | `"http://cp-schema-registry:8081"` | URL of the Kafka schema registry |
 | maxTasks | int | `2` | Maximum number of worker threads inside a connector pod. |
 | mode | string | `"sink"` | Either source or sink |
+| logLevel.root | string | `"INFO"` | Default log level |
+| logLevel.loggers | object | `{"org.reflections":"ERROR"}` | Per-logger log-level |
+| heapOpts | string | `"-Xms1500m"` | Java heap options |
 | source.name | string | `"radar-jdbc-source"` | Name of the connector Kafka producer group |
 | source.schema | string | `"public"` | Database schema (if any) |
 | source.tableWhitelist | string | `""` | Comma-separted list of tables to read |
@@ -57,9 +60,14 @@ A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JD
 | source.mode | string | `"incrementing"` | How to detect new values in a table. |
 | source.incrementingColumnName | string | `""` | When using mode incrementing, which column to use as incrementing. If empty, autodetection will be used. |
 | source.keyField | string | `""` | Field to use as key for the records. If empty, no key is used. |
+| source.persistence.enabled | bool | `true` | Whether to enable persistence for storing offsets |
+| source.persistence.existingClaim | string | `nil` | Existing persistent volume claim to use |
+| source.persistence.accessMode | string | `"ReadWriteOnce"` | PVC access mode |
+| source.persistence.size | string | `"20Mi"` | PVC storage size request |
 | sink.name | string | `"radar-jdbc-sink"` | Name of the connector Kafka consumer group |
 | sink.autoCreate | bool | `true` | create table if it does not exist |
 | sink.insertMode | string | `"upsert"` | How to insert new values into the database |
+| sink.mergeKey | bool | `true` | Whether to merge the key fields into the inserted values. |
 | sink.primaryKeys.mode | string | `"record_value"` | where to read the primary keys from when creating the table |
 | sink.primaryKeys.fields | list | `["time","userId","projectId"]` | fields to include as primary keys when creating the table |
 | sink.topics | string | `"android_phone_relative_location, android_phone_battery_level, connect_upload_altoida_summary, connect_fitbit_intraday_heart_rate, connect_fitbit_intraday_steps"` | Comma-separated list of topics the connector will read from and ingest into the database |

--- a/charts/radar-jdbc-connector/README.md
+++ b/charts/radar-jdbc-connector/README.md
@@ -2,7 +2,7 @@
 
 # radar-jdbc-connector
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.5.2](https://img.shields.io/badge/AppVersion-10.5.2-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.5.2](https://img.shields.io/badge/AppVersion-10.5.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
 
@@ -51,10 +51,12 @@ A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JD
 | maxTasks | int | `2` | Maximum number of worker threads inside a connector pod. |
 | mode | string | `"sink"` | Either source or sink |
 | source.name | string | `"radar-jdbc-source"` | Name of the connector Kafka producer group |
+| source.schema | string | `"public"` | Database schema (if any) |
 | source.tableWhitelist | string | `""` | Comma-separted list of tables to read |
 | source.topicPrefix | string | `""` | Prefix to prepend to table names to generate the name of the Kafka topic to publish data to. |
 | source.mode | string | `"incrementing"` | How to detect new values in a table. |
 | source.incrementingColumnName | string | `""` | When using mode incrementing, which column to use as incrementing. If empty, autodetection will be used. |
+| source.keyField | string | `""` | Field to use as key for the records. If empty, no key is used. |
 | sink.name | string | `"radar-jdbc-sink"` | Name of the connector Kafka consumer group |
 | sink.autoCreate | bool | `true` | create table if it does not exist |
 | sink.insertMode | string | `"upsert"` | How to insert new values into the database |

--- a/charts/radar-jdbc-connector/templates/_helpers.tpl
+++ b/charts/radar-jdbc-connector/templates/_helpers.tpl
@@ -24,6 +24,12 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
+{{- define "radar-jdbc-connector.loggers" -}}
+{{- if .Values.logLevel.loggers }}
+{{- range $name, $level := .Values.logLevel.loggers }}{{(print $name "=" $level ) }},{{- end }}
+{{- end }}
+{{- end }}
+
 {{/*
 Create chart name and version as used by the chart label.
 */}}

--- a/charts/radar-jdbc-connector/templates/configmap.yaml
+++ b/charts/radar-jdbc-connector/templates/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "radar-jdbc-connector.labels" . | nindent 4 }}
 data:
-  sink-timescale.properties: |
+  connector.properties: |
     # Kafka connector configuration
     name = {{ $name }}
 
@@ -26,9 +26,10 @@ data:
     connection.backoff.ms = 600000
 
     {{- if eq .Values.mode "sink" }}
-    {{- with .Values.sink }}
     # Kafka connector configuration
     connector.class = io.confluent.connect.jdbc.JdbcSinkConnector
+
+    {{- with .Values.sink }}
     insert.mode = {{ .insertMode }}
     # Topics that will be consumed
     topics = {{ .topics }}
@@ -38,21 +39,43 @@ data:
     pk.mode = {{ .mode }}
     pk.fields = {{ join ", " .fields }}
     {{- end }}
+
+    {{- end }}
     transforms=mergeKey,timestamp
     transforms.mergeKey.type=org.radarbase.kafka.connect.transforms.MergeKey
     transforms.timestamp.type=org.radarbase.kafka.connect.transforms.TimestampConverter
     transforms.timestamp.fields=time,timeReceived,timeCompleted,timestamp
     {{- end }}
-    {{- end }}
+
     {{- if eq .Values.mode "source" }}
-    {{- with .Values.source }}
     # Kafka connector configuration
     connector.class = io.confluent.connect.jdbc.JdbcSourceConnector
+    {{- with .Values.source }}
+    {{- if .schema }}
+    schema.pattern = {{ .schema }}
+    {{- end }}
     table.whitelist = {{ .tableWhitelist }}
     topic.prefix = {{ .topicPrefix }}
     mode = {{ .mode }}
     incrementing.column.name = {{ .incrementingColumnName }}
+    {{- if .keyField }}
+    transforms=createKey,extractField
+    transforms.createKey.type = org.apache.kafka.connect.transforms.ValueToKey
+    transforms.createKey.fields = {{ .keyField }}
+    transforms.extractField.type = org.apache.kafka.connect.transforms.ExtractField$Key
+    transforms.extractField.field = {{ .keyField }}
     {{- end }}
+
+    {{- end }}
+
+    errors.log.enable = true
+    errors.log.include.messages = true
+    topic.creation.default.replication.factor = 2
+    topic.creation.default.partitions = 3
+    key.converter = io.confluent.connect.avro.AvroConverter
+    key.converter.schema.registry.url = {{ .Values.schema_registry }}
+    value.converter = io.confluent.connect.avro.AvroConverter
+    value.converter.schema.registry.url = {{ .Values.schema_registry }}
     {{- end }}
   healthcheck.sh: |
     #!/bin/sh

--- a/charts/radar-jdbc-connector/templates/configmap.yaml
+++ b/charts/radar-jdbc-connector/templates/configmap.yaml
@@ -1,5 +1,6 @@
 {{- include "radar-jdbc-connector.validateValues" . }}
-{{ $name := ternary  .Values.sink.name .Values.source.name (eq .Values.mode "sink") }}
+{{- $isSource := eq .Values.mode "source" -}}
+{{- $name := ternary  .Values.source.name .Values.sink.name $isSource -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -25,7 +26,7 @@ data:
     # Wait 10 minutes before attempting connection
     connection.backoff.ms = 600000
 
-    {{- if eq .Values.mode "sink" }}
+    {{- if not $isSource }}
     # Kafka connector configuration
     connector.class = io.confluent.connect.jdbc.JdbcSinkConnector
 
@@ -40,14 +41,16 @@ data:
     pk.fields = {{ join ", " .fields }}
     {{- end }}
 
-    {{- end }}
+    {{- if .mergeKey }}
     transforms=mergeKey,timestamp
     transforms.mergeKey.type=org.radarbase.kafka.connect.transforms.MergeKey
     transforms.timestamp.type=org.radarbase.kafka.connect.transforms.TimestampConverter
     transforms.timestamp.fields=time,timeReceived,timeCompleted,timestamp
     {{- end }}
+    {{- end }}
+    {{- end }}
 
-    {{- if eq .Values.mode "source" }}
+    {{- if $isSource }}
     # Kafka connector configuration
     connector.class = io.confluent.connect.jdbc.JdbcSourceConnector
     {{- with .Values.source }}
@@ -65,18 +68,18 @@ data:
     transforms.extractField.type = org.apache.kafka.connect.transforms.ExtractField$Key
     transforms.extractField.field = {{ .keyField }}
     {{- end }}
-
     {{- end }}
-
-    errors.log.enable = true
-    errors.log.include.messages = true
     topic.creation.default.replication.factor = 2
     topic.creation.default.partitions = 3
+    {{- end }}
+
     key.converter = io.confluent.connect.avro.AvroConverter
     key.converter.schema.registry.url = {{ .Values.schema_registry }}
     value.converter = io.confluent.connect.avro.AvroConverter
     value.converter.schema.registry.url = {{ .Values.schema_registry }}
-    {{- end }}
+    errors.log.enable = true
+    errors.log.include.messages = true
+    errors.tolerance = all
   healthcheck.sh: |
     #!/bin/sh
     STATUS=$(curl -sf localhost:8083/connectors/{{ $name }}/status | grep -o '\"state\":\"[^\"]*\"')

--- a/charts/radar-jdbc-connector/templates/deployment.yaml
+++ b/charts/radar-jdbc-connector/templates/deployment.yaml
@@ -1,4 +1,5 @@
-{{- $name := ternary  .Values.sink.name .Values.source.name (eq .Values.mode "sink") -}}
+{{- $isSource := eq .Values.mode "source" -}}
+{{- $name := ternary  .Values.source.name .Values.sink.name $isSource -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -76,8 +77,6 @@ spec:
             value: "/var/lib/kafka-connect-jdbc/logs/connect.offsets"
           - name: CONNECT_REST_ADVERTISED_HOST_NAME
             value: "radar-jdbc-connector"
-          - name: CONNECT_ZOOKEEPER_CONNECT
-            value: "{{ .Values.zookeeper }}"
           - name: CONNECT_CONSUMER_MAX_POLL_RECORDS
             value: "500"
           - name: CONNECT_CONSUMER_MAX_POLL_INTERVAL_MS
@@ -89,15 +88,15 @@ spec:
           - name: CONNECT_PLUGIN_PATH
             value: /usr/share/kafka-connect/plugins
           - name: CONNECT_LOG4J_ROOT_LOGLEVEL
-            value: INFO
+            value: {{ .Values.logLevel.root | quote }}
           - name: KAFKA_BROKERS
             value: "{{ .Values.kafka_num_brokers }}"
           - name: CONNECT_LOG4J_LOGGERS
-            value: "org.reflections=ERROR"
+            value: {{ include "radar-jdbc-connector.loggers" . | trimSuffix "," | quote }}
           - name: CONNECTOR_PROPERTY_FILE_PREFIX
             value: "{{ $name }}/connector"
           - name: KAFKA_HEAP_OPTS
-            value: "-Xms1500m"
+            value: "{{ .Values.heapOpts }}"
           ports:
             - name: http
               containerPort: 8083
@@ -127,10 +126,23 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/kafka-connect/{{ $name }}
+            {{- if $isSource }}
+            - name: offset-storage
+              mountPath: /var/lib/kafka-connect-jdbc/logs
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "radar-jdbc-connector.fullname" . }}
+        {{- if $isSource }}
+        - name: offset-storage
+        {{- if .Values.source.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.source.persistence.existingClaim | default (include "radar-jdbc-connector.fullname" .) }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/radar-jdbc-connector/templates/deployment.yaml
+++ b/charts/radar-jdbc-connector/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $name := ternary  .Values.sink.name .Values.source.name (eq .Values.mode "sink") -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -94,7 +95,7 @@ spec:
           - name: CONNECT_LOG4J_LOGGERS
             value: "org.reflections=ERROR"
           - name: CONNECTOR_PROPERTY_FILE_PREFIX
-            value: "sink-timescale/sink-timescale"
+            value: "{{ $name }}/connector"
           - name: KAFKA_HEAP_OPTS
             value: "-Xms1500m"
           ports:
@@ -105,7 +106,7 @@ spec:
             exec:
               command:
               - /bin/sh
-              - /etc/kafka-connect/sink-timescale/healthcheck.sh
+              - /etc/kafka-connect/{{ $name }}/healthcheck.sh
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 5
@@ -115,7 +116,7 @@ spec:
             exec:
               command:
               - /bin/sh
-              - /etc/kafka-connect/sink-timescale/healthcheck.sh
+              - /etc/kafka-connect/{{ $name }}/healthcheck.sh
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 5
@@ -125,7 +126,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /etc/kafka-connect/sink-timescale
+              mountPath: /etc/kafka-connect/{{ $name }}
       volumes:
         - name: config
           configMap:

--- a/charts/radar-jdbc-connector/templates/pvc.yaml
+++ b/charts/radar-jdbc-connector/templates/pvc.yaml
@@ -1,0 +1,28 @@
+{{- if eq .Values.mode "source" -}}
+{{- with .Values.source.persistence }}
+{{- if and .enabled (not .existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "radar-jdbc-connector.fullname" $ }}
+  labels:
+    app: "{{ template "radar-jdbc-connector.fullname" $ }}"
+    chart: "{{ template "radar-jdbc-connector.chart" $ }}"
+    release: {{ $.Release.Name | quote }}
+    heritage: {{ $.Release.Service | quote }}
+spec:
+  accessModes:
+    - {{ .accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .size | quote }}
+{{- if .storageClass }}
+{{- if (eq "-" .storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .storageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/radar-jdbc-connector/values.yaml
+++ b/charts/radar-jdbc-connector/values.yaml
@@ -77,6 +77,16 @@ maxTasks: 2
 # -- Either source or sink
 mode: sink
 
+logLevel:
+  # -- Default log level
+  root: INFO
+  # -- Per-logger log-level
+  loggers:
+    org.reflections: ERROR
+
+# -- Java heap options
+heapOpts: "-Xms1500m"
+
 source:
   # -- Name of the connector Kafka producer group
   name: radar-jdbc-source
@@ -92,6 +102,15 @@ source:
   incrementingColumnName: ""
   # -- Field to use as key for the records. If empty, no key is used.
   keyField: ""
+  persistence:
+    # -- Whether to enable persistence for storing offsets
+    enabled: true
+    # -- Existing persistent volume claim to use
+    existingClaim:
+    # -- PVC access mode
+    accessMode: ReadWriteOnce
+    # -- PVC storage size request
+    size: 20Mi
 
 sink:
   # -- Name of the connector Kafka consumer group
@@ -100,6 +119,8 @@ sink:
   autoCreate: true
   # -- How to insert new values into the database
   insertMode: upsert
+  # -- Whether to merge the key fields into the inserted values.
+  mergeKey: true
   primaryKeys:
     # -- where to read the primary keys from when creating the table
     mode: record_value

--- a/charts/radar-jdbc-connector/values.yaml
+++ b/charts/radar-jdbc-connector/values.yaml
@@ -80,6 +80,8 @@ mode: sink
 source:
   # -- Name of the connector Kafka producer group
   name: radar-jdbc-source
+  # -- Database schema (if any)
+  schema: public
   # -- Comma-separted list of tables to read
   tableWhitelist: ""
   # -- Prefix to prepend to table names to generate the name of the Kafka topic to publish data to.
@@ -88,6 +90,8 @@ source:
   mode: incrementing
   # -- When using mode incrementing, which column to use as incrementing. If empty, autodetection will be used.
   incrementingColumnName: ""
+  # -- Field to use as key for the records. If empty, no key is used.
+  keyField: ""
 
 sink:
   # -- Name of the connector Kafka consumer group


### PR DESCRIPTION
Adds some properties to the source connector to make it functional. Notable differences:
- autocreate topics for the tables
- add record key by selecting a single field
- use Avro formatting
- add error logs
- only scan a single database schema by default