### PR TITLE
[radar-rest-sources-*] Update radar-rest-sources-* to 4.1.0

### DIFF
--- a/charts/radar-rest-sources-authorizer/Chart.yaml
+++ b/charts/radar-rest-sources-authorizer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "4.0.1"
+appVersion: "4.1.0"
 description: A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 name: radar-rest-sources-authorizer
-version: 0.4.1
+version: 0.4.2
 sources: ["https://github.com/RADAR-base/RADAR-Rest-Source-Auth"]
 deprecated: false
 type: application

--- a/charts/radar-rest-sources-authorizer/README.md
+++ b/charts/radar-rest-sources-authorizer/README.md
@@ -2,7 +2,7 @@
 
 # radar-rest-sources-authorizer
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.1](https://img.shields.io/badge/AppVersion-4.0.1-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
 
 A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 
@@ -31,7 +31,7 @@ A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer
 |-----|------|---------|-------------|
 | replicaCount | int | `2` | Number of radar-rest-sources-authorizer replicas to deploy |
 | image.repository | string | `"radarbase/radar-rest-source-authorizer"` | radar-rest-sources-authorizer image repository |
-| image.tag | string | `"4.0.1"` | radar-rest-sources-authorizer image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"4.1.0"` | radar-rest-sources-authorizer image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | radar-rest-sources-authorizer image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override radar-rest-sources-authorizer.fullname template with a string (will prepend the release name) |
@@ -39,10 +39,10 @@ A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer
 | podSecurityContext | object | `{}` | Configure radar-rest-sources-authorizer pods' Security Context |
 | securityContext | object | `{}` | Configure radar-rest-sources-authorizer containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
-| service.port | int | `80` | radar-rest-sources-authorizer port |
+| service.port | int | `8080` | radar-rest-sources-authorizer port |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
-| ingress.path | string | `"/rest-sources/authorizer/?(.*)"` | Path within the url structure |
+| ingress.path | string | `"/rest-sources/authorizer/"` | Path within the url structure |
 | ingress.pathType | string | `"ImplementationSpecific"` |  |
 | ingress.hosts | list | `["localhost"]` | Hosts to accept requests from |
 | ingress.tls.secretName | string | `"radar-base-tls"` | TLS Secret Name |

--- a/charts/radar-rest-sources-authorizer/templates/deployment.yaml
+++ b/charts/radar-rest-sources-authorizer/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
             value: https://{{ .Values.serverName }}/managementportal/oauth
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/radar-rest-sources-authorizer/values.yaml
+++ b/charts/radar-rest-sources-authorizer/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/radar-rest-source-authorizer
   # -- radar-rest-sources-authorizer image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 4.0.1
+  tag: 4.1.0
   # -- radar-rest-sources-authorizer image pull policy
   pullPolicy: IfNotPresent
 
@@ -39,7 +39,7 @@ service:
   # -- Kubernetes Service type
   type: ClusterIP
   # -- radar-rest-sources-authorizer port
-  port: 80
+  port: 8080
 
 ingress:
   # -- Enable ingress controller resource
@@ -49,9 +49,8 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
   # -- Path within the url structure
-  path: "/rest-sources/authorizer/?(.*)"
+  path: "/rest-sources/authorizer/"
   pathType: ImplementationSpecific
   # -- Hosts to accept requests from
   hosts:

--- a/charts/radar-rest-sources-backend/Chart.yaml
+++ b/charts/radar-rest-sources-backend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "4.0.1"
+appVersion: "4.1.0"
 description: A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 name: radar-rest-sources-backend
-version: 0.4.1
+version: 0.4.2
 sources: ["https://github.com/RADAR-base/RADAR-Rest-Source-Auth"]
 deprecated: false
 type: application

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -2,7 +2,7 @@
 
 # radar-rest-sources-backend
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.1](https://img.shields.io/badge/AppVersion-4.0.1-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 
@@ -31,7 +31,7 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 |-----|------|---------|-------------|
 | replicaCount | int | `2` | Number of radar-rest-sources-backend replicas to deploy |
 | image.repository | string | `"radarbase/radar-rest-source-auth-backend"` | radar-rest-sources-backend image repository |
-| image.tag | string | `"4.0.1"` | radar-rest-sources-backend image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"4.1.0"` | radar-rest-sources-backend image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | radar-rest-sources-backend image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override radar-rest-sources-backend.fullname template with a string (will prepend the release name) |

--- a/charts/radar-rest-sources-backend/values.yaml
+++ b/charts/radar-rest-sources-backend/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/radar-rest-source-auth-backend
   # -- radar-rest-sources-backend image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 4.0.1
+  tag: 4.1.0
   # -- radar-rest-sources-backend image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Updates radar-rest-sources-authorizer and radar-rest-sources-backend to version 4.1.0:
https://github.com/RADAR-base/RADAR-Rest-Source-Auth/releases/tag/v4.1.0

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
