### PR TITLE
[radar-rest-sources-authorizer] Fix healthcheck

### DIFF
--- a/charts/radar-rest-sources-authorizer/Chart.yaml
+++ b/charts/radar-rest-sources-authorizer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.1.0"
 description: A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 name: radar-rest-sources-authorizer
-version: 0.4.2
+version: 0.4.3
 sources: ["https://github.com/RADAR-base/RADAR-Rest-Source-Auth"]
 deprecated: false
 type: application

--- a/charts/radar-rest-sources-authorizer/README.md
+++ b/charts/radar-rest-sources-authorizer/README.md
@@ -2,7 +2,7 @@
 
 # radar-rest-sources-authorizer
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
 
 A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 

--- a/charts/radar-rest-sources-authorizer/templates/deployment.yaml
+++ b/charts/radar-rest-sources-authorizer/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /rest-sources/authorizer/
               port: http
             initialDelaySeconds: 5
             periodSeconds: 30
@@ -79,7 +79,7 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /
+              path: /rest-sources/authorizer/
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
Fix the health check of the radar-rest-sources-authorizer.
**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
