### PR TITLE
[catalog-server] Transform catalog-server as documented

### DIFF
--- a/charts/catalog-server/Chart.yaml
+++ b/charts/catalog-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.0"
 description: A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 name: catalog-server
-version: 0.4.1
+version: 0.4.2
 sources: ["https://github.com/RADAR-base/RADAR-Schemas/tree/master/java-sdk"]
 type: application
 home: "https://radar-base.org"

--- a/charts/catalog-server/README.md
+++ b/charts/catalog-server/README.md
@@ -2,7 +2,7 @@
 
 # catalog-server
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 

--- a/charts/catalog-server/templates/configmap.yaml
+++ b/charts/catalog-server/templates/configmap.yaml
@@ -11,8 +11,8 @@ data:
   config.yaml: |
     # Kafka
     kafka:
-      {{- if .Values.kafkaProperties }}
-      {{- toYaml .Values.kafkaProperties | nindent 6 }}
+      {{- range $key, $value := .Values.kafkaProperties }}
+      {{ $key | replace "_" "." }}: {{ $value }}
       {{- end }}
       {{- if .Values.cc.enabled }}
       bootstrap.servers: {{ .Values.cc.bootstrapServerurl }}


### PR DESCRIPTION
Transforms keys of `kafkaProperties` values, replacing `_` with `.`. This restores documented behaviour and actual of chart version <0.4.0. @yatharthranjan could you test if this indeed fixes #60?

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
