### PR TITLE
Added trivy scanner

### DIFF
--- a/external/trivy/.helmignore
+++ b/external/trivy/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/external/trivy/Chart.yaml
+++ b/external/trivy/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+appVersion: 0.30.4
+description: Trivy helm chart
+keywords:
+- scanner
+- trivy
+- vulnerability
+name: trivy
+sources:
+- https://github.com/aquasecurity/trivy
+version: 0.4.17

--- a/external/trivy/README.md
+++ b/external/trivy/README.md
@@ -1,0 +1,107 @@
+# Trivy Scanner
+
+Trivy vulnerability scanner standalone installation.
+
+## TL;DR;
+
+```
+$ helm install trivy . --namespace trivy --create-namespace
+```
+
+## Introduction
+
+This chart bootstraps a Trivy deployment on a [Kubernetes](http://kubernetes.io) cluster using the
+[Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 3+
+
+## Installing from the Aqua Chart Repository
+
+```
+helm repo add aquasecurity https://aquasecurity.github.io/helm-charts/
+helm repo update
+helm search repo trivy
+helm install my-trivy aquasecurity/trivy
+```
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```
+$ helm install my-release .
+```
+
+The command deploys Trivy on the Kubernetes cluster in the default configuration. The [Parameters](#parameters)
+section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+The following table lists the configurable parameters of the Trivy chart and their default values.
+
+|                 Parameter             |                                Description                              |    Default     |
+|---------------------------------------|-------------------------------------------------------------------------|----------------|
+| `image.registry`                      | Image registry                                                          | `docker.io`    |
+| `image.repository`                    | Image name                                                              | `aquasec/trivy` |
+| `image.tag`                           | Image tag                                                               | `{TAG_NAME}`   |
+| `image.pullPolicy`                    | Image pull policy                                                       | `IfNotPresent` |
+| `image.pullSecret`                    | The name of an imagePullSecret used to pull trivy image from e.g. Docker Hub or a private registry  | |
+| `replicaCount`                        | Number of Trivy Pods to run                                   | `1`            |
+| `trivy.debugMode`                     | The flag to enable or disable Trivy debug mode                          | `false` |
+| `trivy.gitHubToken`                   | The GitHub access token to download Trivy DB. More info: https://github.com/aquasecurity/trivy#github-rate-limiting                          |      |
+| `trivy.registryUsername`              | The username used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |      |
+| `trivy.registryPassword`              | The password used to log in at dockerhub. More info: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/ |      |
+| `trivy.registryCredentialsExistingSecret` | Name of Secret containing dockerhub credentials. Alternative to the 2 parameters above, has precedence if set.                    |      |
+| `trivy.serviceAccount.annotations`        | Additional annotations to add to the Kubernetes service account resource |     |
+| `trivy.skipUpdate`                    | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |
+| `trivy.dbRepository`                  | OCI repository to retrieve the trivy vulnerability database from        | `ghcr.io/aquasecurity/trivy-db`        |
+| `trivy.cache.redis.enabled`           | Enable Redis as caching backend                                         | `false` |
+| `trivy.cache.redis.url`               | Specify redis connection url, e.g. redis://redis.redis.svc:6379         | `` |
+| `trivy.serverToken`                   | The token to authenticate Trivy client with Trivy server                | `` |
+| `trivy.existingSecret`                | existingSecret if an existing secret has been created outside the chart. Overrides gitHubToken, registryUsername, registryPassword, serverToken | `` |
+| `trivy.podAnnotations`                | Annotations for pods created by statefulset                             | `{}` |
+| `service.name`                        | If specified, the name used for the Trivy service                       |     |
+| `service.type`                        | Kubernetes service type                                                 | `ClusterIP` |
+| `service.port`                        | Kubernetes service port                                                 | `4954`      |
+| `httpProxy`                           | The URL of the HTTP proxy server                                        |     |
+| `httpsProxy`                          | The URL of the HTTPS proxy server                                       |     |
+| `noProxy`                             | The URLs that the proxy settings do not apply to                        |     |
+| `nodeSelector`                        | Node labels for pod assignment                                              |     |
+| `affinity`                            | Affinity settings for pod assignment                                              |     |
+| `tolerations`                         | Tolerations for pod assignment                                              |     |
+| `podAnnotations`                      | Annotations for pods created by statefulset                             | `{}` |
+
+The above parameters map to the env variables defined in [trivy](https://github.com/aquasecurity/trivy#configuration).
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+```
+$ helm install my-release . \
+       --namespace my-namespace \
+       --set "service.port=9090" \
+       --set "trivy.vulnType=os\,library"
+```
+
+## Storage
+
+This chart uses a PersistentVolumeClaim to reduce the number of database downloads between POD restarts or updates. The storageclass should have the reclaim policy  `Retain`.
+
+## Caching
+
+You can specify a Redis server as cache backend. This Redis server has to be already present. You can use the [bitnami chart](https://bitnami.com/stack/redis/helm).
+More Information about the caching backends can be found [here](https://github.com/aquasecurity/trivy#specify-cache-backend).

--- a/external/trivy/templates/NOTES.txt
+++ b/external/trivy/templates/NOTES.txt
@@ -1,0 +1,2 @@
+You should be able to access Trivy server installation within
+the cluster at http://{{ include "trivy.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}

--- a/external/trivy/templates/_helpers.tpl
+++ b/external/trivy/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "trivy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "trivy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "trivy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "trivy.labels" -}}
+app.kubernetes.io/name: {{ include "trivy.name" . }}
+helm.sh/chart: {{ include "trivy.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Return the proper imageRef as used by the container template spec.
+*/}}
+{{- define "trivy.imageRef" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion | toString -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}

--- a/external/trivy/templates/configmap.yaml
+++ b/external/trivy/templates/configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "trivy.fullname" . }}
+  labels:
+{{ include "trivy.labels" . | indent 4 }}
+data:
+  TRIVY_LISTEN: "0.0.0.0:{{ .Values.service.port }}"
+  TRIVY_CACHE_DIR: "/home/scanner/.cache/trivy"
+{{- if .Values.trivy.cache.redis.enabled }}
+  TRIVY_CACHE_BACKEND: {{ .Values.trivy.cache.redis.url | quote }}
+{{- end }}
+  TRIVY_DEBUG: {{ .Values.trivy.debugMode | quote }}
+  TRIVY_SKIP_UPDATE: {{ .Values.trivy.skipUpdate | quote }}
+  TRIVY_DB_REPOSITORY: {{ .Values.trivy.dbRepository | quote }}
+{{- if .Values.httpProxy }}
+  HTTP_PROXY: {{ .Values.httpProxy | quote }}
+{{- end }}
+{{- if .Values.httpsProxy }}
+  HTTPS_PROXY: {{ .Values.httpsProxy | quote }}
+{{- end }}
+{{- if .Values.noProxy }}
+  NO_PROXY: {{ .Values.noProxy | quote }}
+{{- end }}

--- a/external/trivy/templates/ingress.yaml
+++ b/external/trivy/templates/ingress.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "trivy.fullname" . -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ include "trivy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "trivy.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if and (.Values.ingress.ingressClassName) (semverCompare ">= v1.18.0" .Capabilities.KubeVersion.Version) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: {{ $.Values.ingress.path }}
+        {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            pathType: {{ $.Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $.Values.service.port -}}
+          {{- else }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $.Values.service.port -}}
+          {{- end }}
+  {{- end }}
+{{- end }}

--- a/external/trivy/templates/podsecuritypolicy.yaml
+++ b/external/trivy/templates/podsecuritypolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.rbac.pspEnabled }}
+  {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "trivy.fullname" . }}
+  labels:
+{{ include "trivy.labels" . | indent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'persistentVolumeClaim'
+    - 'secret'
+    - 'projected'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
+  {{- end }}
+{{- end }}

--- a/external/trivy/templates/role.yaml
+++ b/external/trivy/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "trivy.fullname" . }}
+  labels:
+{{ include "trivy.labels" . | indent 4 }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.rbac.pspEnabled }}
+  {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
+rules:
+- apiGroups:      ['policy']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ include "trivy.fullname" . }}]
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/external/trivy/templates/rolebinding.yaml
+++ b/external/trivy/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "trivy.fullname" . }}
+  labels:
+{{ include "trivy.labels" . | indent 4 }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "trivy.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "trivy.fullname" . }}
+{{- end }}

--- a/external/trivy/templates/secret.yaml
+++ b/external/trivy/templates/secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.trivy.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "trivy.fullname" . }}
+  labels:
+{{ include "trivy.labels" . | indent 4 }}
+type: Opaque
+data:
+  GITHUB_TOKEN: {{ .Values.trivy.gitHubToken | default "" | b64enc | quote }}
+  TRIVY_TOKEN: {{ .Values.trivy.serverToken | default "" | b64enc | quote }}
+{{- if not .Values.trivy.registryCredentialsExistingSecret }}
+  TRIVY_USERNAME: {{ .Values.trivy.registryUsername | default "" | b64enc | quote }}
+  TRIVY_PASSWORD: {{ .Values.trivy.registryPassword | default "" | b64enc | quote }}
+{{- end -}}
+{{- end }}

--- a/external/trivy/templates/service.yaml
+++ b/external/trivy/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name | default (include "trivy.fullname" .) }}
+  labels:
+{{ include "trivy.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type | default "ClusterIP" }}
+  selector:
+    app.kubernetes.io/name: {{ include "trivy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: trivy-http
+      protocol: TCP
+      port: {{ .Values.service.port | default 4954 }}
+      targetPort: {{ .Values.service.port | default 4954 }}
+  sessionAffinity: ClientIP

--- a/external/trivy/templates/serviceaccount.yaml
+++ b/external/trivy/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "trivy.fullname" . }}
+  labels:
+{{ include "trivy.labels" . | indent 4 }}
+{{- if (.Values.trivy.serviceAccount).annotations }}
+  annotations:
+{{ toYaml .Values.trivy.serviceAccount.annotations | indent 4 }}
+{{- end }}
+  namespace: {{ .Release.Namespace }}

--- a/external/trivy/templates/statefulset.yaml
+++ b/external/trivy/templates/statefulset.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "trivy.fullname" . }}
+  labels:
+{{ include "trivy.labels" . | indent 4 }}
+    {{- with .Values.trivy.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  podManagementPolicy: "Parallel"
+  serviceName: {{ include "trivy.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "trivy.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        accessModes:
+          - {{ .Values.persistence.accessMode }}
+        storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ include "trivy.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.trivy.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "trivy.fullname" . }}
+      automountServiceAccountToken: false
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      containers:
+        - name: main
+          image: {{ template "trivy.imageRef" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.securityContext }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
+          {{- end }}
+          args:
+            - server
+          {{- if .Values.trivy.registryCredentialsExistingSecret }}
+          env:
+            - name: TRIVY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.trivy.registryCredentialsExistingSecret }}
+                  key: TRIVY_USERNAME
+            - name: TRIVY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.trivy.registryCredentialsExistingSecret }}
+                  key: TRIVY_PASSWORD
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "trivy.fullname" . }}
+            - secretRef:
+                {{- if not .Values.trivy.existingSecret }}
+                name: {{ include "trivy.fullname" . }}
+                {{- else }}
+                name: {{ .Values.trivy.existingSecret }}
+                {{- end }}
+          ports:
+            - name: trivy-http
+              containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /healthz
+              port: trivy-http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /healthz
+              port: trivy-http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-data
+              readOnly: false
+            - mountPath: /home/scanner/.cache
+              name: data
+              readOnly: false
+          {{- if .Values.resources }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+          {{- end }}
+      volumes:
+        - name: tmp-data
+          emptyDir: {}
+        {{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}

--- a/external/trivy/values.yaml
+++ b/external/trivy/values.yaml
@@ -1,0 +1,156 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  registry: docker.io
+  repository: aquasec/trivy
+  # tag is an override of the image tag, which is by default set by the
+  # appVersion field in Chart.yaml.
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecret: ""
+
+replicaCount: 1
+
+persistence:
+  enabled: true
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 5Gi
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    cpu: 1
+    memory: 1Gi
+
+rbac:
+  create: true
+  pspEnabled: true
+
+podSecurityContext:
+  runAsUser: 65534
+  runAsNonRoot: true
+  fsGroup: 65534
+
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: true
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+## Affinity settings for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+affinity: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+## Annotations for pods created by statefulset
+## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+
+trivy:
+  # debugMode the flag to enable Trivy debug mode
+  debugMode: false
+  # gitHubToken the GitHub access token to download Trivy DB
+  #
+  # Trivy DB contains vulnerability information from NVD, Red Hat, and many other upstream vulnerability databases.
+  # It is downloaded by Trivy from the GitHub release page https://github.com/aquasecurity/trivy-db/releases and cached
+  # in the local file system (`/home/scanner/.cache/trivy/db/trivy.db`). In addition, the database contains the update
+  # timestamp so Trivy can detect whether it should download a newer version from the Internet or use the cached one.
+  # Currently, the database is updated every 12 hours and published as a new release to GitHub.
+  #
+  # Anonymous downloads from GitHub are subject to the limit of 60 requests per hour. Normally such rate limit is enough
+  # for production operations. If, for any reason, it's not enough, you could increase the rate limit to 5000
+  # requests per hour by specifying the GitHub access token. For more details on GitHub rate limiting please consult
+  # https://developer.github.com/v3/#rate-limiting
+  #
+  # You can create a GitHub token by following the instructions in
+  # https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
+  gitHubToken: ""
+
+  # Docker registry credentials
+  # See also: https://aquasecurity.github.io/trivy/dev/advanced/private-registries/docker-hub/
+  #
+  # Either
+  # Directly in this file
+  #
+  # TRIVY_USERNAME
+  registryUsername: ""
+  # TRIVY_PASSWORD
+  registryPassword: ""
+  #
+  # Or
+  # From an existing secret
+  #
+  # The secret must be Opaque and just contain "TRIVY_USERNAME: your_user" and "TRIVY_PASSWORD: your_password" as k/v pairs.
+  # NOTE: When this is set the previous parameters are ignored.
+  #
+  # registryCredentialsExistingSecret: name-of-existing-secret
+  # skipUpdate the flag to enable or disable Trivy DB downloads from GitHub
+  #
+  # You might want to enable this flag in test or CI/CD environments to avoid GitHub rate limiting issues.
+  # If the flag is enabled you have to manually download the `trivy.db` file and mount it in the
+  # `/home/scanner/.cache/trivy/db/trivy.db` path (see `cacheDir`).
+  skipUpdate: false
+  # OCI repository to retrieve the trivy vulnerability database from
+  dbRepository: ghcr.io/aquasecurity/trivy-db
+  # Trivy supports filesystem and redis as caching backend
+  # https://github.com/aquasecurity/trivy#specify-cache-backend
+  # This location is only used for the cache, not the db storage: https://github.com/aquasecurity/trivy/issues/765#issue-756010345
+  #
+  # In case you specify redis as backend, make sure you installed a redis server yourself, e.g.
+  # https://bitnami.com/stack/redis/helm
+  #
+  # In case redis is not enabled, the filesystem will be used
+  cache:
+    redis:
+      enabled: false
+      url: ""  # e.g. redis://redis.redis.svc:6379
+  serviceAccount:
+    annotations: {}
+      # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/IAM_ROLE_NAME
+  # If you want to add custom labels to your statefulset and podTemplate
+  labels: {}
+  # serverToken is the token to authenticate Trivy client with Trivy server.
+  serverToken: ""
+  # existingSecret if an existing secret has been created outside the chart.
+  # Overrides gitHubToken, registryUsername, registryPassword, serverToken
+  existingSecret: ""
+
+service:
+  # If specified, the name used for the Trivy service.
+  name:
+  # type Kubernetes service type
+  type: ClusterIP
+  # port Kubernetes service port
+  port: 4954
+
+ingress:
+  enabled: false
+  # From Kubernetes 1.18+ this field is supported in case your ingress controller supports it. When set, you do not need to add the ingress class as annotation.
+  ingressClassName:
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+  hosts:
+    - host: trivy.example.com
+  path: "/"
+  # type is only needed for networking.k8s.io/v1 in k8s 1.19+
+  pathType: Prefix
+  tls: []
+  #  - secretName: trivy-example-tls
+  #    hosts:
+  #      - trivy.example.com
+
+# httpProxy the URL of the HTTP proxy server
+httpProxy:
+# httpsProxy the URL of the HTTPS proxy server
+httpsProxy:
+# noProxy the URLs that the proxy settings do not apply to
+noProxy:


### PR DESCRIPTION
Trivy continuously scans Kubernetes cluster for security issues, and generates security reports by watching Kubernetes for state changes and automatically triggering scans in response to changes, for example initiating a vulnerability scan when a new Pod is created.

Example output:
```
kubectl get vulnerabilityreports -o wide
NAME                                                            REPOSITORY                                TAG                    SCANNER   AGE   CRITICAL   HIGH   MEDIUM   LOW   UNKNOWN
replicaset-57fffd77d6                                           radarbase/radar-rest-source-authorizer    4.0.0                  Trivy     20h   4          16     13       2     0
replicaset-6577cf85bc                                           ingress-nginx/controller                                         Trivy     20h   4          16     16       2     2
replicaset-78d9b5cf5d                                           solsson/kafka-prometheus-jmx-exporter                            Trivy     20h   23         49     29       35    9
replicaset-7cb65956fb                                           radarbase/radar-upload-connect-frontend   0.5.10                 Trivy     20h   9          52     29       6     0
replicaset-7d68b4cb8                                            radarbase/radar-upload-connect-backend    0.5.10                 Trivy     20h   9          19     20       2     1
replicaset-app-config-658d5768b4-app-config                     radarbase/radar-app-config                0.3.3                  Trivy     20h   10         19     20       2     1
replicaset-app-config-frontend-7b4bcfcd99-app-config-frontend   radarbase/radar-app-config-frontend       0.3.3                  Trivy     20h   4          24     13       2     0
replicaset-catalog-server-59b646844c-catalog-server             radarbase/radar-schemas-tools             0.7.5                  Trivy     20h   5          24     25       4     1
replicaset-catalog-server-59b646844c-kafka-init                 radarbase/radar-schemas-tools             0.7.5                  Trivy     20h   5          24     25       4     1
replicaset-dd7d9448c                                            confluentinc/cp-schema-registry           7.2.0                  Trivy     20h   1          19     40       2     0
replicaset-radar-grafana-85d5c5dcc-download-dashboards          curlimages/curl                           7.73.0                 Trivy     20h   4          27     10       2     0
replicaset-radar-grafana-85d5c5dcc-grafana                      grafana/grafana                           8.0.1                  Trivy     20h   5          49     13       0     9
replicaset-radar-grafana-85d5c5dcc-init-chown-data              library/busybox                           1.31.1                 Trivy     20h   0          0      0        0     0
replicaset-radar-integration-7848d55875-radar-integration       radarbase/radar-redcapintegration         0.1.0                  Trivy     20h   34         78     109      118   1
replicaset-radar-s3-connector-5f484755f8-init-topics            library/alpine                            latest                 Trivy     20h   0          0      0        0     0
replicaset-radar-s3-connector-5f484755f8-radar-s3-connector     radarbase/kafka-connect-transform-s3      7.1.1                  Trivy     20h   4          30     52       6     0
statefulset-cp-kafka-cp-kafka-broker                            confluentinc/cp-kafka                     7.2.0                  Trivy     20h   2          9      29       2     0
statefulset-cp-kafka-init-chown-data                            library/busybox                           1.35.0                 Trivy     20h   0          0      0        0     0
statefulset-cp-kafka-prometheus-jmx-exporter                    solsson/kafka-prometheus-jmx-exporter                            Trivy     20h   23         49     29       35    9
statefulset-postgresql-fsfreeze                                 library/busybox                           latest                 Trivy     20h   0          0      0        0     0
statefulset-postgresql-init-chmod-data                          bitnami/bitnami-shell                     10-debian-10-r406      Trivy     20h   14         21     18       8     3
statefulset-postgresql-metrics                                  bitnami/postgres-exporter                 0.10.1-debian-10-r93   Trivy     20h   16         28     19       8     7
statefulset-postgresql-postgresql                               bitnami/postgresql                        11.16.0                Trivy     20h   3          6      3        2     1
statefulset-redis-master-init-sysctl                            bitnami/bitnami-shell                     10-debian-10-r400      Trivy     20h   14         21     18       8     3
statefulset-redis-master-metrics                                bitnami/redis-exporter                    1.37.0-debian-10-r31   Trivy     20h   16         21     19       8     3
statefulset-redis-master-redis                                  bitnami/redis                             6.2.6-debian-10-r192   Trivy     20h   16         22     22       8     4
```