### PR TITLE
 added configuration for mergeKey and timestamp

### DIFF
--- a/charts/radar-jdbc-connector/Chart.yaml
+++ b/charts/radar-jdbc-connector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "10.5.2"
 name: radar-jdbc-connector
 description: A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
-version: 0.3.0
+version: 0.4.0
 engine: gotpl
 sources: ["https://github.com/RADAR-base/RADAR-JDBC-Connector"]
 deprecated: false

--- a/charts/radar-jdbc-connector/README.md
+++ b/charts/radar-jdbc-connector/README.md
@@ -68,6 +68,9 @@ A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JD
 | sink.autoCreate | bool | `true` | create table if it does not exist |
 | sink.insertMode | string | `"upsert"` | How to insert new values into the database |
 | sink.mergeKey | bool | `true` | Whether to merge the key fields into the inserted values. |
+| sink.transforms.mergeKeyType | string | `org.radarbase.kafka.connect.transforms.MergeKey` | The MergeKey transformation copies all fields from the record key into the record value, and adds a timestamp.|
+| sink.transforms.timestampType | string | `org.radarbase.kafka.connect.transforms.TimestampConverter` | The TimestampConverter transformation converts milliseconds value fields and floating point seconds value fields to logical timestamp fields.|
+| sink.transforms.timestampFields | list | `["time", "timeReceived", "timeCompleted", "timestamp"]` | The timestamp fields that should be converted can be configured with the fields configuration.|
 | sink.primaryKeys.mode | string | `"record_value"` | where to read the primary keys from when creating the table |
 | sink.primaryKeys.fields | list | `["time","userId","projectId"]` | fields to include as primary keys when creating the table |
 | sink.topics | string | `"android_phone_relative_location, android_phone_battery_level, connect_upload_altoida_summary, connect_fitbit_intraday_heart_rate, connect_fitbit_intraday_steps"` | Comma-separated list of topics the connector will read from and ingest into the database |

--- a/charts/radar-jdbc-connector/templates/configmap.yaml
+++ b/charts/radar-jdbc-connector/templates/configmap.yaml
@@ -42,10 +42,12 @@ data:
     {{- end }}
 
     {{- if .mergeKey }}
+    {{- with .transforms }}
     transforms=mergeKey,timestamp
-    transforms.mergeKey.type=org.radarbase.kafka.connect.transforms.MergeKey
-    transforms.timestamp.type=org.radarbase.kafka.connect.transforms.TimestampConverter
-    transforms.timestamp.fields=time,timeReceived,timeCompleted,timestamp
+    transforms.mergeKey.type={{ .mergeKeyType }}
+    transforms.timestamp.type={{ .timestampType }}
+    transforms.timestamp.fields={{ join ", " .timestampFields }}
+    {{- end }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/radar-jdbc-connector/values.yaml
+++ b/charts/radar-jdbc-connector/values.yaml
@@ -121,6 +121,16 @@ sink:
   insertMode: upsert
   # -- Whether to merge the key fields into the inserted values.
   mergeKey: true
+  # -- Setting transforms properties for mergeKey and timestamp
+  transforms:
+    mergeKeyType: org.radarbase.kafka.connect.transforms.MergeKey
+    timestampType: org.radarbase.kafka.connect.transforms.TimestampConverter
+    timestampFields:
+      - time
+      - timeReceived
+      - timeCompleted
+      - timestamp
+
   primaryKeys:
     # -- where to read the primary keys from when creating the table
     mode: record_value


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of maintainers might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Added configuration for `mergeKeys` properties for the radar-jdbc-connector.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

The change would make `transforms.mergeKey` and `transforms.timestamp`configurable. 

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/RADAR-base/RADAR-Kubernetes/pull/207

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
