### PR TITLE
[radar-s3-connector/catalog-server] Fix s3 connector with region and topic generation

### DIFF
--- a/charts/catalog-server/Chart.yaml
+++ b/charts/catalog-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.8.0"
+appVersion: "0.8.2"
 description: A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 name: catalog-server
-version: 0.4.2
+version: 0.4.3
 sources: ["https://github.com/RADAR-base/RADAR-Schemas/tree/master/java-sdk"]
 type: application
 home: "https://radar-base.org"

--- a/charts/catalog-server/README.md
+++ b/charts/catalog-server/README.md
@@ -2,7 +2,7 @@
 
 # catalog-server
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 
@@ -32,7 +32,7 @@ A Helm chart for RADAR-base catalogue server. This application creates RADAR-bas
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of catalog-server replicas to deploy |
 | image.repository | string | `"radarbase/radar-schemas-tools"` | catalog-server image repository |
-| image.tag | string | `"0.8.0"` | catalog-server image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"0.8.2"` | catalog-server image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | catalog-server image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override catalog-server.fullname template with a string (will prepend the release name) |

--- a/charts/catalog-server/values.yaml
+++ b/charts/catalog-server/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/radar-schemas-tools
   # -- catalog-server image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 0.8.0
+  tag: 0.8.2
   # -- catalog-server image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/radar-rest-sources-authorizer/Chart.yaml
+++ b/charts/radar-rest-sources-authorizer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "4.1.0"
+appVersion: "4.1.3"
 description: A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 name: radar-rest-sources-authorizer
-version: 0.4.3
+version: 0.4.4
 sources: ["https://github.com/RADAR-base/RADAR-Rest-Source-Auth"]
 deprecated: false
 type: application

--- a/charts/radar-rest-sources-authorizer/README.md
+++ b/charts/radar-rest-sources-authorizer/README.md
@@ -2,7 +2,7 @@
 
 # radar-rest-sources-authorizer
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
+![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.3](https://img.shields.io/badge/AppVersion-4.1.3-informational?style=flat-square)
 
 A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 
@@ -31,7 +31,7 @@ A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer
 |-----|------|---------|-------------|
 | replicaCount | int | `2` | Number of radar-rest-sources-authorizer replicas to deploy |
 | image.repository | string | `"radarbase/radar-rest-source-authorizer"` | radar-rest-sources-authorizer image repository |
-| image.tag | string | `"4.1.0"` | radar-rest-sources-authorizer image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"4.1.3"` | radar-rest-sources-authorizer image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | radar-rest-sources-authorizer image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override radar-rest-sources-authorizer.fullname template with a string (will prepend the release name) |
@@ -42,7 +42,7 @@ A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer
 | service.port | int | `8080` | radar-rest-sources-authorizer port |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
-| ingress.path | string | `"/rest-sources/authorizer/"` | Path within the url structure |
+| ingress.path | string | `"/rest-sources/authorizer"` | Path within the url structure |
 | ingress.pathType | string | `"ImplementationSpecific"` |  |
 | ingress.hosts | list | `["localhost"]` | Hosts to accept requests from |
 | ingress.tls.secretName | string | `"radar-base-tls"` | TLS Secret Name |

--- a/charts/radar-rest-sources-authorizer/values.yaml
+++ b/charts/radar-rest-sources-authorizer/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/radar-rest-source-authorizer
   # -- radar-rest-sources-authorizer image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 4.1.0
+  tag: 4.1.3
   # -- radar-rest-sources-authorizer image pull policy
   pullPolicy: IfNotPresent
 
@@ -50,7 +50,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
   # -- Path within the url structure
-  path: "/rest-sources/authorizer/"
+  path: /rest-sources/authorizer
   pathType: ImplementationSpecific
   # -- Hosts to accept requests from
   hosts:

--- a/charts/radar-rest-sources-backend/Chart.yaml
+++ b/charts/radar-rest-sources-backend/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "4.1.0"
+appVersion: "4.1.3"
 description: A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 name: radar-rest-sources-backend
-version: 0.4.2
+version: 0.4.3
 sources: ["https://github.com/RADAR-base/RADAR-Rest-Source-Auth"]
 deprecated: false
 type: application

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -2,7 +2,7 @@
 
 # radar-rest-sources-backend
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.3](https://img.shields.io/badge/AppVersion-4.1.3-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 
@@ -31,7 +31,7 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 |-----|------|---------|-------------|
 | replicaCount | int | `2` | Number of radar-rest-sources-backend replicas to deploy |
 | image.repository | string | `"radarbase/radar-rest-source-auth-backend"` | radar-rest-sources-backend image repository |
-| image.tag | string | `"4.1.0"` | radar-rest-sources-backend image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"4.1.3"` | radar-rest-sources-backend image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | radar-rest-sources-backend image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override radar-rest-sources-backend.fullname template with a string (will prepend the release name) |
@@ -42,7 +42,7 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 | service.port | int | `8080` | radar-rest-sources-backend port |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and session configuration |
-| ingress.path | string | `"/rest-sources/backend/?(.*)"` | Path within the url structure |
+| ingress.path | string | `"/rest-sources/backend"` | Path within the url structure |
 | ingress.pathType | string | `"ImplementationSpecific"` |  |
 | ingress.hosts | list | `["localhost"]` | Hosts to accept requests from |
 | ingress.tls.secretName | string | `"radar-base-tls"` | TLS Secret Name |

--- a/charts/radar-rest-sources-backend/values.yaml
+++ b/charts/radar-rest-sources-backend/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/radar-rest-source-auth-backend
   # -- radar-rest-sources-backend image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 4.1.0
+  tag: 4.1.3
   # -- radar-rest-sources-backend image pull policy
   pullPolicy: IfNotPresent
 
@@ -56,7 +56,7 @@ ingress:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
   # -- Path within the url structure
-  path: "/rest-sources/backend/?(.*)"
+  path: /rest-sources/backend
   pathType: ImplementationSpecific
   # -- Hosts to accept requests from
   hosts:

--- a/charts/radar-s3-connector/Chart.yaml
+++ b/charts/radar-s3-connector/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "7.1.1"
+appVersion: "7.3.0"
 description: A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 connector with a custom data transformers. These configurations enable a sink connector. See full list of properties here https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options
 name: radar-s3-connector
-version: 0.2.3
+version: 0.2.4
 sources: ["https://github.com/RADAR-base/kafka-connect-transform-keyvalue", "https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options"]
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-s3-connector/README.md
+++ b/charts/radar-s3-connector/README.md
@@ -2,7 +2,7 @@
 
 # radar-s3-connector
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.3.0](https://img.shields.io/badge/AppVersion-7.3.0-informational?style=flat-square)
 
 A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 connector with a custom data transformers. These configurations enable a sink connector. See full list of properties here https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options
 
@@ -32,7 +32,7 @@ A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 conne
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of radar-s3-connector replicas to deploy |
 | image.repository | string | `"radarbase/kafka-connect-transform-s3"` | radar-s3-connector image repository |
-| image.tag | string | `"7.1.1"` | radar-s3-connector image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"7.3.0"` | radar-s3-connector image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | radar-s3-connector image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override radar-s3-connector.fullname template with a string (will prepend the release name) |
@@ -50,11 +50,11 @@ A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 conne
 | catalogServer.url | string | `"http://catalog-server:9010"` | Catalog server URL |
 | environment | object | `{"CONNECT_SECURITY_PROTOCOL":"PLAINTEXT"}` | Additional environment variables to pass to the connector. These can be used to pass supported kafka and connect specifc [configs](https://docs.confluent.io/platform/current/installation/docker/config-reference.html#kconnect-long-configuration) |
 | environment.CONNECT_SECURITY_PROTOCOL | string | `"PLAINTEXT"` | Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL. |
-| topics | string | check values.yaml | List of topics to be consumed by the sink connector separated by comma. |
+| topics | string | `""` | List of topics to be consumed by the sink connector separated by comma. Topics defined in the catalog server will automatically be loaded if `initTopics.enabled` is true. |
 | s3Endpoint | string | `"http://minio:9000/"` | Target S3 endpoint url |
 | s3Tagging | bool | `false` | set to true, if S3 objects should be tagged with start and end offsets, as well as record count. |
 | s3PartSize | int | `5242880` | The Part Size in S3 Multi-part Uploads. |
-| s3Region | string | `nil` | The AWS region to be used the connector. |
+| s3Region | string | `nil` | The AWS region to be used the connector. Some compatibility layers require this. |
 | flushSize | int | `10000` | Number of records written to store before invoking file commits. |
 | rotateInterval | int | `900000` | The time interval in milliseconds to invoke file commits. |
 | maxTasks | int | `4` | Number of tasks in the connector |
@@ -68,3 +68,7 @@ A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 conne
 | cc.apiSecret | string | `"ccApiSecret"` | API secret of the Confluent Cloud cluster |
 | cc.schemaRegistryApiKey | string | `"srApiKey"` | API Key of the Confluent Cloud Schema registry |
 | cc.schemaRegistryApiSecret | string | `"srApiSecret"` | API Key of the Confluent Cloud Schema registry |
+| initTopics.enabled | bool | `true` | If true, fetch list of topics from catalog server |
+| initTopics.image.repository | string | `"linuxserver/yq"` | Image repository to fetch topics with |
+| initTopics.image.tag | string | `"3.1.0"` | Image tag to fetch topics with |
+| initTopics.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy to fetch topics with |

--- a/charts/radar-s3-connector/templates/configmap.yaml
+++ b/charts/radar-s3-connector/templates/configmap.yaml
@@ -21,9 +21,10 @@ data:
     s3.part.size={{ .Values.s3PartSize | int }}
     s3.object.tagging={{ .Values.s3Tagging }}
     connect.meta.data=false
-    {{- if not .Values.s3Region }}
+    {{- if .Values.s3Endpoint }}
     store.url={{ .Values.s3Endpoint }}
     {{- end }}
+    s3.object.tagging=true
     storage.class=io.confluent.connect.s3.storage.S3Storage
     format.class=io.confluent.connect.s3.format.avro.AvroFormat
     transforms=combineKeyValue
@@ -47,10 +48,11 @@ data:
       exit 1
     fi
   add-topics-to-config.sh: |
-    #!/bin/sh
+    #!/usr/bin/env sh
     SOURCE=$1
     TARGET=$2
     set -e
-    apk add --no-cache curl jq
-    TOPICS=$(curl -f {{ .Values.catalogServer.url }}/source-types | jq -r '[to_entries[] | select(.key|endswith("source-types")) | .value[].data[].topic] | unique | join(",")')
+    TOPICS=$(curl -sf {{ .Values.catalogServer.url }}/source-types | jq -r '[to_entries | .[] | select(.key | test("^.*-source-types$")) | .value[].data[].topic] | sort | unique | join(",")')
     sed "s/^topics=.\+\$/\\0,$TOPICS/" "$SOURCE" | sed "s/^topics=\$/\\0$TOPICS/" > "$TARGET"
+    echo "Configured the following topics"
+    grep "topics=" "$TARGET"

--- a/charts/radar-s3-connector/templates/deployment.yaml
+++ b/charts/radar-s3-connector/templates/deployment.yaml
@@ -229,12 +229,14 @@ spec:
           volumeMounts:
             - name: config-original
               mountPath: /etc/kafka-connect/sink-s3/original
-            - name: config-updated
+            - name: {{ if .Values.initTopics.enabled }}config-updated{{ else }}config-original{{ end }}
               mountPath: /etc/kafka-connect/sink-s3
+      {{- if .Values.initTopics.enabled }}
       initContainers:
         - name: init-topics
-          image: alpine:latest
-          args:
+          image: {{ .Values.initTopics.image.repository }}:{{ .Values.initTopics.image.tag }}
+          imagePullPolicy: {{ .Values.initTopics.image.pullPolicy }}
+          command:
             - /bin/sh
             - /etc/kafka-connect/sink-s3/original/add-topics-to-config.sh
             - /etc/kafka-connect/sink-s3/original/sink-s3.properties
@@ -244,6 +246,7 @@ spec:
               mountPath: /etc/kafka-connect/sink-s3/original
             - name: config-updated
               mountPath: /etc/kafka-connect/sink-s3
+      {{- end }}
       volumes:
         - name: config-original
           configMap:

--- a/charts/radar-s3-connector/values.yaml
+++ b/charts/radar-s3-connector/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/kafka-connect-transform-s3
   # -- radar-s3-connector image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "7.1.1"
+  tag: "7.3.0"
   # -- radar-s3-connector image pull policy
   pullPolicy: IfNotPresent
 
@@ -81,16 +81,16 @@ environment:
   # -- Protocol used to communicate with brokers. Valid values are: PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL.
   CONNECT_SECURITY_PROTOCOL: PLAINTEXT
 
-# -- List of topics to be consumed by the sink connector separated by comma.
-# @default -- check values.yaml
-topics: android_phone_usage_event_output,android_biovotion_vsm1_acceleration,android_biovotion_vsm1_battery_level,android_biovotion_vsm1_blood_volume_pulse,android_biovotion_vsm1_energy,android_biovotion_vsm1_galvanic_skin_response,android_biovotion_vsm1_heartrate,android_biovotion_vsm1_heartrate_variability,android_biovotion_vsm1_led_current,android_biovotion_vsm1_oxygen_saturation,android_biovotion_vsm1_ppg_raw,android_biovotion_vsm1_respiration_rate,android_biovotion_vsm1_temperature,android_bittium_faros_acceleration,android_bittium_faros_battery_level,android_bittium_faros_ecg,android_bittium_faros_inter_beat_interval,android_bittium_faros_temperature,android_empatica_e4_acceleration,android_empatica_e4_battery_level,android_empatica_e4_blood_volume_pulse,android_empatica_e4_electrodermal_activity,android_empatica_e4_inter_beat_interval,android_empatica_e4_sensor_status,android_empatica_e4_temperature,android_local_weather,android_pebble_2_acceleration,android_pebble_2_battery_level,android_pebble_2_heartrate,android_pebble_2_heartrate_filtered,android_phone_acceleration,android_phone_battery_level,android_phone_bluetooth_devices,android_phone_call,android_phone_contacts,android_phone_gyroscope,android_phone_light,android_phone_magnetic_field,android_phone_ppg,android_phone_relative_location,android_phone_sms,android_phone_sms_unread,android_phone_step_count,android_phone_usage_event,android_phone_user_interaction,android_processed_audio,application_device_info,application_external_time,application_record_counts,application_server_status,application_time_zone,application_uptime,certh_banking_app_event,certh_banking_app_transaction,connect_fitbit_activity_log,connect_fitbit_intraday_calories,connect_fitbit_intraday_heart_rate,connect_fitbit_intraday_steps,connect_fitbit_sleep_classic,connect_fitbit_sleep_stages,connect_fitbit_time_zone,connect_upload_altoida_acceleration,connect_upload_altoida_action,connect_upload_altoida_attitude,connect_upload_altoida_bit_metrics,connect_upload_altoida_blink,connect_upload_altoida_diagnostics,connect_upload_altoida_domain_result,connect_upload_altoida_dot_metrics,connect_upload_altoida_eye_tracking,connect_upload_altoida_gravity,connect_upload_altoida_magnetic_field,connect_upload_altoida_metadata,connect_upload_altoida_object,connect_upload_altoida_path,connect_upload_altoida_rotation,connect_upload_altoida_summary,connect_upload_altoida_tap,connect_upload_altoida_touch,connect_upload_axivity_acceleration,connect_upload_axivity_battery_level,connect_upload_axivity_event,connect_upload_axivity_light,connect_upload_axivity_metadata,connect_upload_axivity_temperature,connect_upload_oxford_camera_data,connect_upload_oxford_camera_image,connect_upload_physilog_binary_data,notification_thinc_it,questionnaire_app_event,questionnaire_ari_self,questionnaire_art_cognitive_test,questionnaire_audio,questionnaire_baars_iv,questionnaire_bipq,questionnaire_completion_log,questionnaire_esm,questionnaire_esm28q,questionnaire_esm_epi_mod_1,questionnaire_evening_assessment,questionnaire_gad7,questionnaire_morning_assessment,questionnaire_patient_determined_disease_step,questionnaire_perceived_deficits_questionnaire,questionnaire_phq8,questionnaire_rpq,questionnaire_rses,questionnaire_tam,questionnaire_timezone,task_2MW_test,task_romberg_test,task_tandem_walking_test,thincit_code_breaker,thincit_pdq5,thincit_spotter,thincit_symbol_check,thincit_trails,
+# -- List of topics to be consumed by the sink connector separated by comma. Topics defined in the catalog server
+# will automatically be loaded if `initTopics.enabled` is true.
+topics: ""
 # -- Target S3 endpoint url
 s3Endpoint: http://minio:9000/
 # -- set to true, if S3 objects should be tagged with start and end offsets, as well as record count.
 s3Tagging: false
 # -- The Part Size in S3 Multi-part Uploads.
 s3PartSize: 5242880
-# -- The AWS region to be used the connector.
+# -- The AWS region to be used the connector. Some compatibility layers require this.
 s3Region:
 # -- Number of records written to store before invoking file commits.
 flushSize: 10000
@@ -120,3 +120,15 @@ cc:
   schemaRegistryApiKey: srApiKey
   # -- API Key of the Confluent Cloud Schema registry
   schemaRegistryApiSecret: srApiSecret
+
+initTopics:
+  # -- If true, fetch list of topics from catalog server
+  enabled: true
+
+  image:
+    # -- Image repository to fetch topics with
+    repository: linuxserver/yq
+    # -- Image tag to fetch topics with
+    tag: 3.1.0
+    # -- Image pull policy to fetch topics with
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
**Description of the change**

- Adds a S3 region if necessary
- Enable object tagging
- Fix catalog server
- Use a base image for getting topics that already has `jq` and `curl`
- Bump rest source authoriser.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
