### PR TITLE
[radar-s3-connector] bump tag and fix object tagging

### DIFF
--- a/charts/radar-s3-connector/Chart.yaml
+++ b/charts/radar-s3-connector/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "7.3.0"
+appVersion: "7.3.1"
 description: A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 connector with a custom data transformers. These configurations enable a sink connector. See full list of properties here https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options
 name: radar-s3-connector
-version: 0.2.4
+version: 0.2.5
 sources: ["https://github.com/RADAR-base/kafka-connect-transform-keyvalue", "https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options"]
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-s3-connector/README.md
+++ b/charts/radar-s3-connector/README.md
@@ -2,7 +2,7 @@
 
 # radar-s3-connector
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.3.0](https://img.shields.io/badge/AppVersion-7.3.0-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.3.1](https://img.shields.io/badge/AppVersion-7.3.1-informational?style=flat-square)
 
 A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 connector with a custom data transformers. These configurations enable a sink connector. See full list of properties here https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options
 
@@ -32,7 +32,7 @@ A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 conne
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of radar-s3-connector replicas to deploy |
 | image.repository | string | `"radarbase/kafka-connect-transform-s3"` | radar-s3-connector image repository |
-| image.tag | string | `"7.3.0"` | radar-s3-connector image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"7.3.1"` | radar-s3-connector image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | radar-s3-connector image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override radar-s3-connector.fullname template with a string (will prepend the release name) |

--- a/charts/radar-s3-connector/templates/configmap.yaml
+++ b/charts/radar-s3-connector/templates/configmap.yaml
@@ -24,7 +24,6 @@ data:
     {{- if .Values.s3Endpoint }}
     store.url={{ .Values.s3Endpoint }}
     {{- end }}
-    s3.object.tagging=true
     storage.class=io.confluent.connect.s3.storage.S3Storage
     format.class=io.confluent.connect.s3.format.avro.AvroFormat
     transforms=combineKeyValue

--- a/charts/radar-s3-connector/values.yaml
+++ b/charts/radar-s3-connector/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: radarbase/kafka-connect-transform-s3
   # -- radar-s3-connector image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "7.3.0"
+  tag: "7.3.1"
   # -- radar-s3-connector image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
- Bumps radar-s3-connector from 7.3.0 to 7.3.1
- Fixes object tagging value; it would be overridden by a fixed value in configmaps.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
