### PR TITLE
Change MP resource request format

### DIFF
--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.1"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 0.2.5
+version: 0.2.6
 engine: gotpl
 sources: ["https://github.com/RADAR-base/ManagementPortal"]
 deprecated: false

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -2,7 +2,7 @@
 
 # management-portal
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 
@@ -46,7 +46,7 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 | ingress.pathType | string | `"ImplementationSpecific"` |  |
 | ingress.hosts | list | `["localhost"]` | Hosts to accept requests from |
 | ingress.tls.secretName | string | `"radar-base-tls"` | TLS Secret Name |
-| resources.limits | object | `{"cpu":2,"memory":"1.7Gi"}` | CPU/Memory resource limits |
+| resources.limits | object | `{"cpu":2,"memory":"1700Mi"}` | CPU/Memory resource limits |
 | resources.requests | object | `{"cpu":"100m","memory":"512Mi"}` | CPU/Memory resource requests |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | tolerations | list | `[]` | Toleration labels for pod assignment |

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -76,7 +76,7 @@ resources:
   # -- CPU/Memory resource limits
   limits:
     cpu: 2
-    memory: 1.7Gi
+    memory: 1700Mi
   # -- CPU/Memory resource requests
   requests:
     cpu: 100m


### PR DESCRIPTION
For some reason using `1.7Gi` was failing and had to use `1700Mi` instead.