### PR TITLE
[radar-home] Added appconfig link

### DIFF
--- a/charts/radar-home/Chart.yaml
+++ b/charts/radar-home/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "0.1.2"
+appVersion: "0.1.3"
 description: RADAR-base home page.
 name: radar-home
-version: 0.1.1
+version: 0.1.2
 sources: ["https://github.com/RADAR-base/radar-home"]
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-home/README.md
+++ b/charts/radar-home/README.md
@@ -2,7 +2,7 @@
 
 # radar-home
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
 
 RADAR-base home page.
 
@@ -30,7 +30,7 @@ RADAR-base home page.
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of Appconfig replicas to deploy |
 | image.repository | string | `"radarbase/radar-home"` | Appconfig image repository |
-| image.tag | string | `"0.1.2"` | Appconfig image tag (immutable tags are recommended) |
+| image.tag | string | `"0.1.3"` | Appconfig image tag (immutable tags are recommended) |
 | image.pullPolicy | string | `"IfNotPresent"` | Appconfig image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override management-portal.fullname template with a string (will prepend the release name) |
@@ -53,6 +53,7 @@ RADAR-base home page.
 | s3.url | string | `nil` | URL to S3 |
 | dashboard.enabled | bool | `false` | Enable link to dashboard |
 | dashboard.url | string | `nil` | URL to dashboard |
+| appConfig.enabled | bool | `false` | Enable link to app-config service |
 | uploadPortal.enabled | bool | `false` | Enable link to upload portal |
 | restAuthorizer.enabled | bool | `false` | Enable link to rest source authorizer |
 | monitoring.enabled | bool | `false` | Enable link to the monitoring stack, usually Prometheus |

--- a/charts/radar-home/templates/deployment.yaml
+++ b/charts/radar-home/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
             - name: UPLOAD_PORTAL_ENABLED
               value: "true"
             {{- end }}
+            {{- if .Values.appConfig.enabled }}
+            - name: APP_CONFIG_ENABLED
+              value: "true"
+            {{- end }}
             {{- if .Values.logging.enabled }}
             - name: GRAYLOG_ENABLED
               value: "true"

--- a/charts/radar-home/values.yaml
+++ b/charts/radar-home/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- Appconfig image repository
   repository: radarbase/radar-home
   # -- Appconfig image tag (immutable tags are recommended)
-  tag: 0.1.2
+  tag: 0.1.3
   # -- Appconfig image pull policy
   pullPolicy: IfNotPresent
 
@@ -82,6 +82,10 @@ dashboard:
   enabled: false
   # -- URL to dashboard
   url:
+
+appConfig:
+  # -- Enable link to app-config service
+  enabled: false
 
 uploadPortal:
   # -- Enable link to upload portal


### PR DESCRIPTION
[radar-home 0.1.3](https://github.com/RADAR-base/radar-home/releases/tag/v0.1.3) adds appconfig link.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
