### PR TITLE
Add Artifacthub integration

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,4 +1,4 @@
-name: Lint and Test Charts
+name: Lint Charts
 
 on:
   pull_request:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -53,6 +53,7 @@ jobs:
         run: ct lint --config .github/ct-lint.yaml
 
   lint-artifacthub:
+    runs-on: ubuntu-20.04
     container:
       image: artifacthub/ah
     steps:

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -56,9 +56,10 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: artifacthub/ah
+      options: --user root
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -51,6 +51,23 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct-lint.yaml
+
+  lint-artifacthub:
+    container:
+      image: artifacthub/ah
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Lint internal charts
+        working-directory: ./charts/
+        run: ah lint
+
+      - name: Lint external charts
+        working-directory: ./external/
+        run: ah lint
   #
   # test:
   #   runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # radar-helm-charts
 
+[![Build](https://github.com/RADAR-base/radar-helm-charts/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/RADAR-base/radar-helm-charts/actions/workflows/lint-test.yaml)
 [![Apache Licensed](https://img.shields.io/github/license/radar-base/radar-kubernetes)](LICENSE)
 [![Join our community Slack](https://img.shields.io/badge/slack-radarbase-success.svg?logo=slack)](https://docs.google.com/forms/d/e/1FAIpQLScKNZ-QonmxNkekDMLLbP-b_IrNHyDRuQValBy1BAsLOjEFpg/viewform)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # radar-helm-charts
 
+[![Apache Licensed](https://img.shields.io/github/license/radar-base/radar-kubernetes)](LICENSE)
+[![Join our community Slack](https://img.shields.io/badge/slack-radarbase-success.svg?logo=slack)](https://docs.google.com/forms/d/e/1FAIpQLScKNZ-QonmxNkekDMLLbP-b_IrNHyDRuQValBy1BAsLOjEFpg/viewform)
+
 The helm charts of the RADAR-base platform. Installation of these charts is best managed via [RADAR-Kubernetes](https://github.com/RADAR-base/RADAR-Kubernetes). Use the releases in this repository by referencing helm repository `radar` with URL <https://radar-base.github.com/radar-helm-charts>.
 
 ## About
 
-RADAR-base is an open-source platform designed to support remote clinical trials by collecting continuous data from wearables and mobile applications. RADAR-Kubernetes enables installing the RADAR-base platform onto Kubernetes clusters. RADAR-base platform can be used for wide range of use-cases. Depending on the use-case, the selection of applications need to be installed can vary. Please read the [component overview and breakdown](https://radar-base.atlassian.net/wiki/spaces/RAD/pages/2673967112/Component+overview+and+breakdown) to understand the role of each component and how components work together. 
+RADAR-base is an open-source platform designed to support remote clinical trials by collecting continuous data from wearables and mobile applications. RADAR-Kubernetes enables installing the RADAR-base platform onto Kubernetes clusters. RADAR-base platform can be used for wide range of use-cases. Depending on the use-case, the selection of applications need to be installed can vary. Please read the [component overview and breakdown](https://radar-base.atlassian.net/wiki/spaces/RAD/pages/2673967112/Component+overview+and+breakdown) to understand the role of each component and how components work together.
 
 The radar-helm-charts setup uses [Helm 3](https://github.com/helm/helm) charts to package necessary Kubernetes resources for each component.
 
@@ -14,11 +17,11 @@ This documentation assumes familiarity with all referenced Kubernetes concepts, 
 
 The following tools should be installed in your local machine to install the RADAR-Kubernetes on your Kubernetes cluster.
 
-| Component | Description |
-|-----|------|
-| [helm 3](https://github.com/helm/helm#install)| Helm Charts are used to package Kubernetes resources for each component|
-| kubernetes | The charts support Kubernetes versions 1.19 up to 1.22. |
-| [helm-docs](https://github.com/norwoodj/helm-docs) | README generator for each chart. |
+| Component                                          | Description                                                             |
+| -------------------------------------------------- | ----------------------------------------------------------------------- |
+| [helm 3](https://github.com/helm/helm#install)     | Helm Charts are used to package Kubernetes resources for each component |
+| kubernetes                                         | The charts support Kubernetes versions 1.19 up to 1.22.                 |
+| [helm-docs](https://github.com/norwoodj/helm-docs) | README generator for each chart.                                        |
 
 Installation of these charts is best managed via [RADAR-Kubernetes](https://github.com/RADAR-base/RADAR-Kubernetes).
 
@@ -27,6 +30,7 @@ Installation of these charts is best managed via [RADAR-Kubernetes](https://gith
 The radar-helm-charts Github project publishes a Helm repository `radar` with URL <https://radar-base.github.com/radar-helm-charts>. Any time a commit to the `main` branch is made that modified one of the helm charts, a new Github release is created for that chart. It is also published to the Helm repository. For that reason, ensure that the `Chart.yaml` file of the respective Helm chart is up to date for any commit made to `main`. In general, the `main` branch should only be updated via Github pull requests.
 
 Before making a PR back to the `main`, ensure that the README of the chart is up to date using the command:
+
 ```
 helm-docs -s file --template-files=charts/_templates.gotmpl --template-files=DOCS.md.gotmpl --template-files=README.md.gotmpl --chart-search-root=charts
 ```
@@ -37,33 +41,33 @@ In each chart directory use the following files to define what the README conten
 
 1. In `README.md.gotmpl` define which sections should be printed to README, with syntax
 
-    ```
-    {{ template "chart.header" . }}
-    {{ template "chart.deprecationWarning" . }}
+   ```
+   {{ template "chart.header" . }}
+   {{ template "chart.deprecationWarning" . }}
 
-    {{ template "chart.badgesSection" . }}
+   {{ template "chart.badgesSection" . }}
 
-    {{ template "chart.description" . }}
+   {{ template "chart.description" . }}
 
-    {{ template "chart.homepageLine" . }}
+   {{ template "chart.homepageLine" . }}
 
-    {{ template "chart.maintainersSection" . }}
+   {{ template "chart.maintainersSection" . }}
 
-    {{ template "chart.sourcesSection" . }}
+   {{ template "chart.sourcesSection" . }}
 
-    {{ template "common.prerequisites" . }}
+   {{ template "common.prerequisites" . }}
 
-    {{ template "chart.requirementsSection" . }}
+   {{ template "chart.requirementsSection" . }}
 
-    {{ template "chart.valuesSection" . }}
-    ```
+   {{ template "chart.valuesSection" . }}
+   ```
 
 2. In `DOCS.md.gotmpl`, define any sections not part of helm-docs:
 
-    ```
-    {{ define "mychart.usageSection" -}}
-    {{- end }}
-    ```
+   ```
+   {{ define "mychart.usageSection" -}}
+   {{- end }}
+   ```
 
 3. In `Chart.yaml` define as many metadata fields as possible, including at least the description, homepage, maintainer, sources, and requirements.
 4. In the `values.yaml` file, put a comment line before each variable with two dashes `--`. Any text after the two dashes will be used as documentation for that variable.
@@ -71,4 +75,4 @@ In each chart directory use the following files to define what the README conten
 ## Feedback and Contributions
 
 Enabling RADAR-base community to use RADAR-Kubernetes is important for us. If you have troubles setting up the platform using provided instructions, you can create an issue with exact details to reproduce and the expected behaviour.
-You can also reach out to the RADAR-base community via RADAR-base Slack on **[radar-kubernetes channel](https://radardevelopment.slack.com/archives/C021AGGESC9)**. The RADAR-base developers support the community on a voluntary basis and will pick up your requests as time permits. 
+You can also reach out to the RADAR-base community via RADAR-base Slack on **[radar-kubernetes channel](https://radardevelopment.slack.com/archives/C021AGGESC9)**. The RADAR-base developers support the community on a voluntary basis and will pick up your requests as time permits.

--- a/charts/_templates.gotmpl
+++ b/charts/_templates.gotmpl
@@ -1,11 +1,15 @@
 {{ define "common.prerequisites" -}}
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 {{- end }}
 
 {{ define "common.prerequisiteswithpv" -}}
 {{ template "common.prerequisites" . }}
 * PV provisioner support in the underlying infrastructure
+{{- end }}
+
+{{ define "common.header" -}}
+{{ template "chart.header" . }}[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/{{ template "chart.name" . }})](https://artifacthub.io/packages/helm/radar-base/{{ template "chart.name" . }})
 {{- end }}

--- a/charts/app-config-frontend/Chart.yaml
+++ b/charts/app-config-frontend/Chart.yaml
@@ -15,14 +15,22 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 appVersion: "0.4.2"
-sources: ["https://github.com/RADAR-base/radar-app-config"]
 home: "https://radar-base.org"
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/app-config-frontend
+- https://github.com/RADAR-base/radar-app-config
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 maintainers:
   - email: keyvan@thehyve.nl
     name: Keyvan Hedayati

--- a/charts/app-config-frontend/README.md
+++ b/charts/app-config-frontend/README.md
@@ -1,8 +1,9 @@
 
 
 # app-config-frontend
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/app-config-frontend)](https://artifacthub.io/packages/helm/radar-base/app-config-frontend)
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
 
 A Helm chart for the frontend application of RADAR-base application config (app-config).
 
@@ -18,6 +19,7 @@ A Helm chart for the frontend application of RADAR-base application config (app-
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/app-config-frontend>
 * <https://github.com/RADAR-base/radar-app-config>
 
 ## Prerequisites

--- a/charts/app-config-frontend/README.md
+++ b/charts/app-config-frontend/README.md
@@ -23,8 +23,8 @@ A Helm chart for the frontend application of RADAR-base application config (app-
 * <https://github.com/RADAR-base/radar-app-config>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/app-config-frontend/README.md.gotmpl
+++ b/charts/app-config-frontend/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/app-config/Chart.yaml
+++ b/charts/app-config/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "0.4.2"
 description: A Helm chart for RADAR-base application config (app-config) backend service which is used as mobile app configuration engine with per-project and per-user configuration.
 name: app-config
-version: 0.2.4
-sources: ["https://github.com/RADAR-base/radar-app-config"]
+version: 0.2.5
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/app-config
+- https://github.com/RADAR-base/radar-app-config
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 type: application
 home: "https://radar-base.org"
 maintainers:

--- a/charts/app-config/README.md
+++ b/charts/app-config/README.md
@@ -23,8 +23,8 @@ A Helm chart for RADAR-base application config (app-config) backend service whic
 * <https://github.com/RADAR-base/radar-app-config>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/app-config/README.md
+++ b/charts/app-config/README.md
@@ -1,8 +1,9 @@
 
 
 # app-config
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/app-config)](https://artifacthub.io/packages/helm/radar-base/app-config)
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
+![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base application config (app-config) backend service which is used as mobile app configuration engine with per-project and per-user configuration.
 
@@ -18,6 +19,7 @@ A Helm chart for RADAR-base application config (app-config) backend service whic
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/app-config>
 * <https://github.com/RADAR-base/radar-app-config>
 
 ## Prerequisites

--- a/charts/app-config/README.md.gotmpl
+++ b/charts/app-config/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/catalog-server/Chart.yaml
+++ b/charts/catalog-server/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "0.8.2"
 description: A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 name: catalog-server
-version: 0.4.4
-sources: ["https://github.com/RADAR-base/RADAR-Schemas/tree/master/java-sdk"]
+version: 0.4.5
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/catalog-server
+- https://github.com/RADAR-base/RADAR-Schemas/tree/master/java-sdk
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 type: application
 home: "https://radar-base.org"
 maintainers:

--- a/charts/catalog-server/Chart.yaml
+++ b/charts/catalog-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.2"
 description: A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 name: catalog-server
-version: 0.4.5
+version: 0.4.6
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/catalog-server

--- a/charts/catalog-server/README.md
+++ b/charts/catalog-server/README.md
@@ -23,8 +23,8 @@ A Helm chart for RADAR-base catalogue server. This application creates RADAR-bas
 * <https://github.com/RADAR-base/RADAR-Schemas/tree/master/java-sdk>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 * PV provisioner support in the underlying infrastructure
 

--- a/charts/catalog-server/README.md
+++ b/charts/catalog-server/README.md
@@ -3,7 +3,7 @@
 # catalog-server
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/catalog-server)](https://artifacthub.io/packages/helm/radar-base/catalog-server)
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 

--- a/charts/catalog-server/README.md
+++ b/charts/catalog-server/README.md
@@ -1,8 +1,9 @@
 
 
 # catalog-server
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/catalog-server)](https://artifacthub.io/packages/helm/radar-base/catalog-server)
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.2](https://img.shields.io/badge/AppVersion-0.8.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 
@@ -18,6 +19,7 @@ A Helm chart for RADAR-base catalogue server. This application creates RADAR-bas
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/catalog-server>
 * <https://github.com/RADAR-base/RADAR-Schemas/tree/master/java-sdk>
 
 ## Prerequisites

--- a/charts/catalog-server/README.md.gotmpl
+++ b/charts/catalog-server/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/cc-schema-registry-proxy/Chart.yaml
+++ b/charts/cc-schema-registry-proxy/Chart.yaml
@@ -2,9 +2,17 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Confluent Cloud schema registry proxy. This proxy service is used when RADAR-base platform is used with Confluent Cloud based schema registry. It forwards requests to schema registry with an additonal basic authentication header with Confluent Cloud schema registry credentials. This service will be enabled if `cc.enabled = true`.
 name: cc-schema-registry-proxy
-version: 0.2.3
+version: 0.2.4
 type: application
 home: "https://radar-base.org"
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/cc-schema-registry-proxy
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 maintainers:
   - email: keyvan@thehyve.nl
     name: Keyvan Hedayati

--- a/charts/cc-schema-registry-proxy/README.md
+++ b/charts/cc-schema-registry-proxy/README.md
@@ -22,8 +22,8 @@ A Helm chart for Confluent Cloud schema registry proxy. This proxy service is us
 * <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/cc-schema-registry-proxy>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/cc-schema-registry-proxy/README.md
+++ b/charts/cc-schema-registry-proxy/README.md
@@ -1,8 +1,9 @@
 
 
 # cc-schema-registry-proxy
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cc-schema-registry-proxy)](https://artifacthub.io/packages/helm/radar-base/cc-schema-registry-proxy)
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for Confluent Cloud schema registry proxy. This proxy service is used when RADAR-base platform is used with Confluent Cloud based schema registry. It forwards requests to schema registry with an additonal basic authentication header with Confluent Cloud schema registry credentials. This service will be enabled if `cc.enabled = true`.
 
@@ -15,6 +16,10 @@ A Helm chart for Confluent Cloud schema registry proxy. This proxy service is us
 | Keyvan Hedayati | <keyvan@thehyve.nl> | <https://www.thehyve.nl> |
 | Joris Borgdorff | <joris@thehyve.nl> | <https://www.thehyve.nl/experts/joris-borgdorff> |
 | Nivethika Mahasivam | <nivethika@thehyve.nl> | <https://www.thehyve.nl/experts/nivethika-mahasivam> |
+
+## Source Code
+
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/cc-schema-registry-proxy>
 
 ## Prerequisites
 * Kubernetes 1.17+

--- a/charts/cc-schema-registry-proxy/README.md.gotmpl
+++ b/charts/cc-schema-registry-proxy/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/cert-manager-letsencrypt/Chart.yaml
+++ b/charts/cert-manager-letsencrypt/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for a cert-manager ClusterIssuer for letsencrypt. Requires the cert-manager release to be activated.
 name: cert-manager-letsencrypt
-version: 0.1.0
-engine: gotpl
+version: 0.1.1
 sources: ["https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/cert-manager-letsencrypt"]
 deprecated: false
 type: application

--- a/charts/cert-manager-letsencrypt/README.md
+++ b/charts/cert-manager-letsencrypt/README.md
@@ -3,7 +3,7 @@
 # cert-manager-letsencrypt
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cert-manager-letsencrypt)](https://artifacthub.io/packages/helm/radar-base/cert-manager-letsencrypt)
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for a cert-manager ClusterIssuer for letsencrypt. Requires the cert-manager release to be activated.
 
@@ -20,8 +20,8 @@ A Helm chart for a cert-manager ClusterIssuer for letsencrypt. Requires the cert
 * <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/cert-manager-letsencrypt>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/cert-manager-letsencrypt/README.md
+++ b/charts/cert-manager-letsencrypt/README.md
@@ -1,6 +1,7 @@
 
 
 # cert-manager-letsencrypt
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cert-manager-letsencrypt)](https://artifacthub.io/packages/helm/radar-base/cert-manager-letsencrypt)
 
 ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 

--- a/charts/cert-manager-letsencrypt/README.md.gotmpl
+++ b/charts/cert-manager-letsencrypt/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -3,7 +3,6 @@ appVersion: "0.60.1"
 description: A Helm chart for Prometheus operator stack. This chart is an overlay for original kube-prometheus-stack chart. It defines some the default values for namespaces to monitor, alert templates, Nginx configuration and authentication and a few extra charts for Grafana. For more details on how to customize those values refer to original chart.
 name: kube-prometheus-stack
 version: 0.4.0
-engine: gotpl
 sources: ["https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack"]
 deprecated: false
 type: application

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.60.1"
 description: A Helm chart for Prometheus operator stack. This chart is an overlay for original kube-prometheus-stack chart. It defines some the default values for namespaces to monitor, alert templates, Nginx configuration and authentication and a few extra charts for Grafana. For more details on how to customize those values refer to original chart.
 name: kube-prometheus-stack
-version: 0.4.0
+version: 0.4.1
 sources: ["https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack"]
 deprecated: false
 type: application

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -3,7 +3,7 @@
 # kube-prometheus-stack
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kube-prometheus-stack)](https://artifacthub.io/packages/helm/radar-base/kube-prometheus-stack)
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.60.1](https://img.shields.io/badge/AppVersion-0.60.1-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.60.1](https://img.shields.io/badge/AppVersion-0.60.1-informational?style=flat-square)
 
 A Helm chart for Prometheus operator stack. This chart is an overlay for original kube-prometheus-stack chart. It defines some the default values for namespaces to monitor, alert templates, Nginx configuration and authentication and a few extra charts for Grafana. For more details on how to customize those values refer to original chart.
 
@@ -14,8 +14,8 @@ A Helm chart for Prometheus operator stack. This chart is an overlay for origina
 * <https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 * PV provisioner support in the underlying infrastructure
 

--- a/charts/kube-prometheus-stack/README.md
+++ b/charts/kube-prometheus-stack/README.md
@@ -1,6 +1,7 @@
 
 
 # kube-prometheus-stack
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kube-prometheus-stack)](https://artifacthub.io/packages/helm/radar-base/kube-prometheus-stack)
 
 ![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.60.1](https://img.shields.io/badge/AppVersion-0.60.1-informational?style=flat-square)
 

--- a/charts/kube-prometheus-stack/README.md.gotmpl
+++ b/charts/kube-prometheus-stack/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.1"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 0.2.6
+version: 0.2.7
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal

--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -3,8 +3,15 @@ appVersion: "0.8.1"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
 version: 0.2.6
-engine: gotpl
-sources: ["https://github.com/RADAR-base/ManagementPortal"]
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal
+- https://github.com/RADAR-base/ManagementPortal
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -1,6 +1,7 @@
 
 
 # management-portal
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
 ![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
@@ -18,6 +19,7 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal>
 * <https://github.com/RADAR-base/ManagementPortal>
 
 ## Prerequisites

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -3,7 +3,7 @@
 # management-portal
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 
@@ -23,8 +23,8 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 * <https://github.com/RADAR-base/ManagementPortal>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/management-portal/README.md.gotmpl
+++ b/charts/management-portal/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-appserver/Chart.yaml
+++ b/charts/radar-appserver/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "3.2.0"
 description: A Helm chart for the backend application of RADAR-base Appserver
 name: radar-appserver
-version: 0.1.4
-sources: ["https://github.com/RADAR-base/RADAR-Appserver"]
+version: 0.1.5
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-appserver
+- https://github.com/RADAR-base/RADAR-Appserver
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-appserver/README.md
+++ b/charts/radar-appserver/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-appserver
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-appserver)](https://artifacthub.io/packages/helm/radar-base/radar-appserver)
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Appserver
 
@@ -17,6 +18,7 @@ A Helm chart for the backend application of RADAR-base Appserver
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-appserver>
 * <https://github.com/RADAR-base/RADAR-Appserver>
 
 ## Prerequisites

--- a/charts/radar-appserver/README.md
+++ b/charts/radar-appserver/README.md
@@ -22,8 +22,8 @@ A Helm chart for the backend application of RADAR-base Appserver
 * <https://github.com/RADAR-base/RADAR-Appserver>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-appserver/README.md.gotmpl
+++ b/charts/radar-appserver/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-backend/Chart.yaml
+++ b/charts/radar-backend/Chart.yaml
@@ -3,6 +3,18 @@ appVersion: "0.4.0"
 description: A Helm chart for RADAR-Base backend services which provides a layer to monitor and analyze streams of wearable data and write data to  storage.
 name: radar-backend
 version: 0.1.2
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-backend
+- https://github.com/RADAR-base/RADAR-Appserver
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
+deprecated: false
+type: application
+home: "https://radar-base.org"
 maintainers:
   - email: keyvan@thehyve.nl
     name: Keyvan Hedayati

--- a/charts/radar-backend/Chart.yaml
+++ b/charts/radar-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.4.0"
 description: A Helm chart for RADAR-Base backend services which provides a layer to monitor and analyze streams of wearable data and write data to  storage.
 name: radar-backend
-version: 0.1.2
+version: 0.1.3
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-backend

--- a/charts/radar-fitbit-connector/Chart.yaml
+++ b/charts/radar-fitbit-connector/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "0.4.0"
 description: A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 name: radar-fitbit-connector
-version: 0.2.2
-sources: ["https://github.com/RADAR-base/RADAR-REST-Connector"]
+version: 0.2.3
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-fitbit-connector
+- https://github.com/RADAR-base/RADAR-REST-Connector
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-fitbit-connector/README.md
+++ b/charts/radar-fitbit-connector/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-fitbit-connector
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-fitbit-connector)](https://artifacthub.io/packages/helm/radar-base/radar-fitbit-connector)
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 
@@ -18,6 +19,7 @@ A Helm chart for RADAR-base fitbit connector. This application collects data fro
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-fitbit-connector>
 * <https://github.com/RADAR-base/RADAR-REST-Connector>
 
 ## Prerequisites

--- a/charts/radar-fitbit-connector/README.md
+++ b/charts/radar-fitbit-connector/README.md
@@ -23,8 +23,8 @@ A Helm chart for RADAR-base fitbit connector. This application collects data fro
 * <https://github.com/RADAR-base/RADAR-REST-Connector>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 * PV provisioner support in the underlying infrastructure
 

--- a/charts/radar-fitbit-connector/README.md.gotmpl
+++ b/charts/radar-fitbit-connector/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "0.5.14"
 description: A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 name: radar-gateway
-version: 0.2.6
-sources: ["https://github.com/RADAR-base/RADAR-Gateway"]
+version: 0.2.7
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-gateway
+- https://github.com/RADAR-base/RADAR-Gateway
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -23,8 +23,8 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 * <https://github.com/RADAR-base/RADAR-Gateway>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-gateway
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-gateway)](https://artifacthub.io/packages/helm/radar-base/radar-gateway)
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
+![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
 
 A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 
@@ -18,6 +19,7 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-gateway>
 * <https://github.com/RADAR-base/RADAR-Gateway>
 
 ## Prerequisites

--- a/charts/radar-gateway/README.md.gotmpl
+++ b/charts/radar-gateway/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-home/Chart.yaml
+++ b/charts/radar-home/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "0.1.3"
 description: RADAR-base home page.
 name: radar-home
-version: 0.1.2
-sources: ["https://github.com/RADAR-base/radar-home"]
+version: 0.1.3
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-home
+- https://github.com/RADAR-base/radar-home
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 type: application
 home: "https://radar-base.org"
 maintainers:

--- a/charts/radar-home/README.md
+++ b/charts/radar-home/README.md
@@ -22,8 +22,8 @@ RADAR-base home page.
 * <https://github.com/RADAR-base/radar-home>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-home/README.md
+++ b/charts/radar-home/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-home
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-home)](https://artifacthub.io/packages/helm/radar-base/radar-home)
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.3](https://img.shields.io/badge/AppVersion-0.1.3-informational?style=flat-square)
 
 RADAR-base home page.
 
@@ -17,6 +18,7 @@ RADAR-base home page.
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-home>
 * <https://github.com/RADAR-base/radar-home>
 
 ## Prerequisites

--- a/charts/radar-home/README.md.gotmpl
+++ b/charts/radar-home/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-integration/Chart.yaml
+++ b/charts/radar-integration/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "1.0.4"
 description: A Helm chart for RADAR-Base REDCap survey integration application.
 name: radar-integration
-version: 0.4.0
-sources: ["https://github.com/RADAR-base/RADAR-RedcapIntegration"]
+version: 0.4.1
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-integration
+- https://github.com/RADAR-base/RADAR-RedcapIntegration
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-integration/README.md
+++ b/charts/radar-integration/README.md
@@ -22,8 +22,8 @@ A Helm chart for RADAR-Base REDCap survey integration application.
 * <https://github.com/RADAR-base/RADAR-RedcapIntegration>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-integration/README.md
+++ b/charts/radar-integration/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-integration
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-integration)](https://artifacthub.io/packages/helm/radar-base/radar-integration)
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.4](https://img.shields.io/badge/AppVersion-1.0.4-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.4](https://img.shields.io/badge/AppVersion-1.0.4-informational?style=flat-square)
 
 A Helm chart for RADAR-Base REDCap survey integration application.
 
@@ -17,6 +18,7 @@ A Helm chart for RADAR-Base REDCap survey integration application.
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-integration>
 * <https://github.com/RADAR-base/RADAR-RedcapIntegration>
 
 ## Prerequisites

--- a/charts/radar-integration/README.md.gotmpl
+++ b/charts/radar-integration/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-jdbc-connector/Chart.yaml
+++ b/charts/radar-jdbc-connector/Chart.yaml
@@ -2,9 +2,16 @@ apiVersion: v2
 appVersion: "10.5.2"
 name: radar-jdbc-connector
 description: A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
-version: 0.4.1
-engine: gotpl
-sources: ["https://github.com/RADAR-base/RADAR-JDBC-Connector"]
+version: 0.4.2
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-jdbc-connector
+- https://github.com/RADAR-base/RADAR-JDBC-Connector
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-jdbc-connector/README.md
+++ b/charts/radar-jdbc-connector/README.md
@@ -24,8 +24,8 @@ A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JD
 * <https://github.com/RADAR-base/RADAR-JDBC-Connector>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-jdbc-connector/README.md
+++ b/charts/radar-jdbc-connector/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-jdbc-connector
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-jdbc-connector)](https://artifacthub.io/packages/helm/radar-base/radar-jdbc-connector)
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.5.2](https://img.shields.io/badge/AppVersion-10.5.2-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.5.2](https://img.shields.io/badge/AppVersion-10.5.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
 
@@ -19,6 +20,7 @@ A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JD
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-jdbc-connector>
 * <https://github.com/RADAR-base/RADAR-JDBC-Connector>
 
 ## Prerequisites

--- a/charts/radar-jdbc-connector/README.md.gotmpl
+++ b/charts/radar-jdbc-connector/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-output/Chart.yaml
+++ b/charts/radar-output/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.3.1"
 description: A Helm chart for RADAR-base output restructure service. This application reads data from intermediate storage and restructure the data into project-> subject-id-> data topic -> data split per hour. This service offers few options to choose the source and target of the pipeline.
 name: radar-output
-version: 0.3.2
+version: 0.3.3
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-output

--- a/charts/radar-output/Chart.yaml
+++ b/charts/radar-output/Chart.yaml
@@ -3,7 +3,15 @@ appVersion: "2.3.1"
 description: A Helm chart for RADAR-base output restructure service. This application reads data from intermediate storage and restructure the data into project-> subject-id-> data topic -> data split per hour. This service offers few options to choose the source and target of the pipeline.
 name: radar-output
 version: 0.3.2
-sources: ["https://github.com/RADAR-base/radar-output-restructure"]
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-output
+- https://github.com/RADAR-base/radar-output-restructure
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 type: application
 home: "https://radar-base.org"
 maintainers:

--- a/charts/radar-output/README.md
+++ b/charts/radar-output/README.md
@@ -3,7 +3,7 @@
 # radar-output
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-output)](https://artifacthub.io/packages/helm/radar-base/radar-output)
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
 
 A Helm chart for RADAR-base output restructure service. This application reads data from intermediate storage and restructure the data into project-> subject-id-> data topic -> data split per hour. This service offers few options to choose the source and target of the pipeline.
 
@@ -23,8 +23,8 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 * <https://github.com/RADAR-base/radar-output-restructure>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-output/README.md
+++ b/charts/radar-output/README.md
@@ -1,6 +1,7 @@
 
 
 # radar-output
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-output)](https://artifacthub.io/packages/helm/radar-base/radar-output)
 
 ![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
 
@@ -18,6 +19,7 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-output>
 * <https://github.com/RADAR-base/radar-output-restructure>
 
 ## Prerequisites

--- a/charts/radar-output/README.md.gotmpl
+++ b/charts/radar-output/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-push-endpoint/Chart.yaml
+++ b/charts/radar-push-endpoint/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "0.2.2"
 description: A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming data from Push or Subscription based WEB APIs. It performs authentication, authorization and content validation. For more details of the configurations, see https://github.com/RADAR-base/RADAR-PushEndpoint.
 name: radar-push-endpoint
-version: 0.1.4
-sources: ["https://github.com/RADAR-base/RADAR-PushEndpoint"]
+version: 0.1.5
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-push-endpoint
+- https://github.com/RADAR-base/RADAR-PushEndpoint
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-push-endpoint/README.md
+++ b/charts/radar-push-endpoint/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-push-endpoint
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-push-endpoint)](https://artifacthub.io/packages/helm/radar-base/radar-push-endpoint)
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming data from Push or Subscription based WEB APIs. It performs authentication, authorization and content validation. For more details of the configurations, see https://github.com/RADAR-base/RADAR-PushEndpoint.
 
@@ -17,6 +18,7 @@ A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming d
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-push-endpoint>
 * <https://github.com/RADAR-base/RADAR-PushEndpoint>
 
 ## Prerequisites

--- a/charts/radar-push-endpoint/README.md
+++ b/charts/radar-push-endpoint/README.md
@@ -22,8 +22,8 @@ A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming d
 * <https://github.com/RADAR-base/RADAR-PushEndpoint>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-push-endpoint/README.md.gotmpl
+++ b/charts/radar-push-endpoint/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-rest-sources-authorizer/Chart.yaml
+++ b/charts/radar-rest-sources-authorizer/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "4.2.0"
 description: A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 name: radar-rest-sources-authorizer
-version: 0.4.6
-sources: ["https://github.com/RADAR-base/RADAR-Rest-Source-Auth"]
+version: 0.4.7
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-authorizer
+- https://github.com/RADAR-base/RADAR-Rest-Source-Auth
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-rest-sources-authorizer/README.md
+++ b/charts/radar-rest-sources-authorizer/README.md
@@ -23,8 +23,8 @@ A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer
 * <https://github.com/RADAR-base/RADAR-Rest-Source-Auth>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-rest-sources-authorizer/README.md
+++ b/charts/radar-rest-sources-authorizer/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-rest-sources-authorizer
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-rest-sources-authorizer)](https://artifacthub.io/packages/helm/radar-base/radar-rest-sources-authorizer)
 
-![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.2.0](https://img.shields.io/badge/AppVersion-4.2.0-informational?style=flat-square)
+![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.2.0](https://img.shields.io/badge/AppVersion-4.2.0-informational?style=flat-square)
 
 A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 
@@ -18,6 +19,7 @@ A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-authorizer>
 * <https://github.com/RADAR-base/RADAR-Rest-Source-Auth>
 
 ## Prerequisites

--- a/charts/radar-rest-sources-authorizer/README.md.gotmpl
+++ b/charts/radar-rest-sources-authorizer/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-rest-sources-backend/Chart.yaml
+++ b/charts/radar-rest-sources-backend/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "4.2.0"
 description: A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 name: radar-rest-sources-backend
-version: 0.4.7
-sources: ["https://github.com/RADAR-base/RADAR-Rest-Source-Auth"]
+version: 0.4.8
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-backend
+- https://github.com/RADAR-base/RADAR-Rest-Source-Auth
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -23,8 +23,8 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 * <https://github.com/RADAR-base/RADAR-Rest-Source-Auth>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-rest-sources-backend
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-rest-sources-backend)](https://artifacthub.io/packages/helm/radar-base/radar-rest-sources-backend)
 
-![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.2.0](https://img.shields.io/badge/AppVersion-4.2.0-informational?style=flat-square)
+![Version: 0.4.8](https://img.shields.io/badge/Version-0.4.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.2.0](https://img.shields.io/badge/AppVersion-4.2.0-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 
@@ -18,6 +19,7 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-backend>
 * <https://github.com/RADAR-base/RADAR-Rest-Source-Auth>
 
 ## Prerequisites

--- a/charts/radar-rest-sources-backend/README.md.gotmpl
+++ b/charts/radar-rest-sources-backend/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-s3-connector/Chart.yaml
+++ b/charts/radar-s3-connector/Chart.yaml
@@ -2,8 +2,17 @@ apiVersion: v2
 appVersion: "7.3.1"
 description: A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 connector with a custom data transformers. These configurations enable a sink connector. See full list of properties here https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options
 name: radar-s3-connector
-version: 0.2.5
-sources: ["https://github.com/RADAR-base/kafka-connect-transform-keyvalue", "https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options"]
+version: 0.2.6
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-s3-connector
+- https://github.com/RADAR-base/kafka-connect-transform-keyvalue
+- https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 type: application
 home: "https://radar-base.org"
 maintainers:

--- a/charts/radar-s3-connector/README.md
+++ b/charts/radar-s3-connector/README.md
@@ -24,8 +24,8 @@ A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 conne
 * <https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-s3-connector/README.md
+++ b/charts/radar-s3-connector/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-s3-connector
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-s3-connector)](https://artifacthub.io/packages/helm/radar-base/radar-s3-connector)
 
-![Version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.3.1](https://img.shields.io/badge/AppVersion-7.3.1-informational?style=flat-square)
+![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.3.1](https://img.shields.io/badge/AppVersion-7.3.1-informational?style=flat-square)
 
 A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 connector with a custom data transformers. These configurations enable a sink connector. See full list of properties here https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options
 
@@ -18,6 +19,7 @@ A Helm chart for RADAR-base s3 connector. This connector uses Confluent s3 conne
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-s3-connector>
 * <https://github.com/RADAR-base/kafka-connect-transform-keyvalue>
 * <https://docs.confluent.io/kafka-connect-s3-sink/current/configuration_options.html#s3-configuration-options>
 

--- a/charts/radar-s3-connector/README.md.gotmpl
+++ b/charts/radar-s3-connector/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-upload-connect-backend/Chart.yaml
+++ b/charts/radar-upload-connect-backend/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "0.5.10"
 description: A Helm chart for RADAR-base upload connector backend application. This application is an upload system that stores uploaded data and its metadata in PostgreSQL for later processing.
 name: radar-upload-connect-backend
-version: 0.2.3
-sources: ["https://github.com/RADAR-base/radar-upload-source-connector"]
+version: 0.2.4
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-upload-connect-backend
+- https://github.com/RADAR-base/radar-upload-source-connector
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-upload-connect-backend/README.md
+++ b/charts/radar-upload-connect-backend/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-upload-connect-backend
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-upload-connect-backend)](https://artifacthub.io/packages/helm/radar-base/radar-upload-connect-backend)
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.10](https://img.shields.io/badge/AppVersion-0.5.10-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.10](https://img.shields.io/badge/AppVersion-0.5.10-informational?style=flat-square)
 
 A Helm chart for RADAR-base upload connector backend application. This application is an upload system that stores uploaded data and its metadata in PostgreSQL for later processing.
 
@@ -18,6 +19,7 @@ A Helm chart for RADAR-base upload connector backend application. This applicati
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-upload-connect-backend>
 * <https://github.com/RADAR-base/radar-upload-source-connector>
 
 ## Prerequisites

--- a/charts/radar-upload-connect-backend/README.md
+++ b/charts/radar-upload-connect-backend/README.md
@@ -23,8 +23,8 @@ A Helm chart for RADAR-base upload connector backend application. This applicati
 * <https://github.com/RADAR-base/radar-upload-source-connector>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-upload-connect-backend/README.md.gotmpl
+++ b/charts/radar-upload-connect-backend/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-upload-connect-frontend/Chart.yaml
+++ b/charts/radar-upload-connect-frontend/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "0.5.10"
 description: A Helm chart for RADAR-base upload connector frontend application that provides a UI for uploading files and sending them to the upload-backend.
 name: radar-upload-connect-frontend
-version: 0.2.3
-sources: ["https://github.com/RADAR-base/radar-upload-source-connector"]
+version: 0.2.4
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-upload-connect-frontend
+- https://github.com/RADAR-base/radar-upload-source-connector
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-upload-connect-frontend/README.md
+++ b/charts/radar-upload-connect-frontend/README.md
@@ -23,8 +23,8 @@ A Helm chart for RADAR-base upload connector frontend application that provides 
 * <https://github.com/RADAR-base/radar-upload-source-connector>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-upload-connect-frontend/README.md
+++ b/charts/radar-upload-connect-frontend/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-upload-connect-frontend
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-upload-connect-frontend)](https://artifacthub.io/packages/helm/radar-base/radar-upload-connect-frontend)
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.10](https://img.shields.io/badge/AppVersion-0.5.10-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.10](https://img.shields.io/badge/AppVersion-0.5.10-informational?style=flat-square)
 
 A Helm chart for RADAR-base upload connector frontend application that provides a UI for uploading files and sending them to the upload-backend.
 
@@ -18,6 +19,7 @@ A Helm chart for RADAR-base upload connector frontend application that provides 
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-upload-connect-frontend>
 * <https://github.com/RADAR-base/radar-upload-source-connector>
 
 ## Prerequisites

--- a/charts/radar-upload-connect-frontend/README.md.gotmpl
+++ b/charts/radar-upload-connect-frontend/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/radar-upload-source-connector/Chart.yaml
+++ b/charts/radar-upload-source-connector/Chart.yaml
@@ -2,8 +2,16 @@ apiVersion: v2
 appVersion: "0.5.10"
 description: A Helm chart for RADAR-base upload kafka connector. This is used for reading uploaded data from backend and sending them to Kafka cluster for later processing.
 name: radar-upload-source-connector
-version: 0.2.2
-sources: ["https://github.com/RADAR-base/radar-upload-source-connector"]
+version: 0.2.3
+icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
+sources:
+- https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-upload-source-connector
+- https://github.com/RADAR-base/radar-upload-source-connector
+keywords:
+  - radar-base
+  - remote-trial
+annotations:
+  artifacthub.io/license: Apache-2.0
 deprecated: false
 type: application
 home: "https://radar-base.org"

--- a/charts/radar-upload-source-connector/README.md
+++ b/charts/radar-upload-source-connector/README.md
@@ -1,8 +1,9 @@
 
 
 # radar-upload-source-connector
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-upload-source-connector)](https://artifacthub.io/packages/helm/radar-base/radar-upload-source-connector)
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.10](https://img.shields.io/badge/AppVersion-0.5.10-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.10](https://img.shields.io/badge/AppVersion-0.5.10-informational?style=flat-square)
 
 A Helm chart for RADAR-base upload kafka connector. This is used for reading uploaded data from backend and sending them to Kafka cluster for later processing.
 
@@ -18,6 +19,7 @@ A Helm chart for RADAR-base upload kafka connector. This is used for reading upl
 
 ## Source Code
 
+* <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-upload-source-connector>
 * <https://github.com/RADAR-base/radar-upload-source-connector>
 
 ## Prerequisites

--- a/charts/radar-upload-source-connector/README.md
+++ b/charts/radar-upload-source-connector/README.md
@@ -23,8 +23,8 @@ A Helm chart for RADAR-base upload kafka connector. This is used for reading upl
 * <https://github.com/RADAR-base/radar-upload-source-connector>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/radar-upload-source-connector/README.md.gotmpl
+++ b/charts/radar-upload-source-connector/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/s3-proxy/Chart.yaml
+++ b/charts/s3-proxy/Chart.yaml
@@ -5,7 +5,7 @@ sources: ["https://github.com/gaul/s3proxy"]
 type: application
 home: "https://radar-base.org"
 name: s3-proxy
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - email: keyvan@thehyve.nl
     name: Keyvan Hedayati

--- a/charts/s3-proxy/README.md
+++ b/charts/s3-proxy/README.md
@@ -1,6 +1,7 @@
 
 
 # s3-proxy
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/s3-proxy)](https://artifacthub.io/packages/helm/radar-base/s3-proxy)
 
 ![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 

--- a/charts/s3-proxy/README.md
+++ b/charts/s3-proxy/README.md
@@ -3,7 +3,7 @@
 # s3-proxy
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/s3-proxy)](https://artifacthub.io/packages/helm/radar-base/s3-proxy)
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for S3 Proxy. It uses https://hub.docker.com/r/andrewgaul/s3proxy to proxy S3 API requests to any supported cloud provider. For more examples see Find some example configurations at https://github.com/gaul/s3proxy/wiki/Storage-backend-examples.
 
@@ -22,8 +22,8 @@ A Helm chart for S3 Proxy. It uses https://hub.docker.com/r/andrewgaul/s3proxy t
 * <https://github.com/gaul/s3proxy>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 
 ## Values

--- a/charts/s3-proxy/README.md.gotmpl
+++ b/charts/s3-proxy/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}

--- a/charts/velero-s3-deployment/Chart.yaml
+++ b/charts/velero-s3-deployment/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Velero S3 deployment, this chart holds resources used by Velero with a deployment to mirror the local object storage to a remote object storage.
 name: velero-s3-deployment
-version: 0.1.0
-engine: gotpl
+version: 0.1.1
 sources: ["https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/velero-s3-deployment"]
 deprecated: false
 type: application

--- a/charts/velero-s3-deployment/README.md
+++ b/charts/velero-s3-deployment/README.md
@@ -3,7 +3,7 @@
 # velero-s3-deployment
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/velero-s3-deployment)](https://artifacthub.io/packages/helm/radar-base/velero-s3-deployment)
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for Velero S3 deployment, this chart holds resources used by Velero with a deployment to mirror the local object storage to a remote object storage.
 
@@ -22,8 +22,8 @@ A Helm chart for Velero S3 deployment, this chart holds resources used by Velero
 * <https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/velero-s3-deployment>
 
 ## Prerequisites
-* Kubernetes 1.17+
-* Kubectl 1.17+
+* Kubernetes 1.22+
+* Kubectl 1.22+
 * Helm 3.1.0+
 * S3-compatible object storage
 

--- a/charts/velero-s3-deployment/README.md
+++ b/charts/velero-s3-deployment/README.md
@@ -1,6 +1,7 @@
 
 
 # velero-s3-deployment
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/velero-s3-deployment)](https://artifacthub.io/packages/helm/radar-base/velero-s3-deployment)
 
 ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 

--- a/charts/velero-s3-deployment/README.md.gotmpl
+++ b/charts/velero-s3-deployment/README.md.gotmpl
@@ -1,4 +1,4 @@
-{{ template "chart.header" . }}
+{{ template "common.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
 {{ template "chart.badgesSection" . }}


### PR DESCRIPTION
Artifacthub shows charts in a nice format and it's good for comparing changes between versions, it does also give vulnerability report for images used in that helm chart. With this PR our charts there should look more neat.
https://artifacthub.io/packages/search?org=radar-base&sort=relevance&page=1