### PR TITLE
 velero: bugfix: BackOffLimitExceeded GLIBC not found

### DIFF
--- a/charts/velero-s3-deployment/Chart.yaml
+++ b/charts/velero-s3-deployment/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Velero S3 deployment, this chart holds resources used by Velero with a deployment to mirror the local object storage to a remote object storage.
 name: velero-s3-deployment
-version: 0.2.1
+version: 0.2.2
 sources: ["https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/velero-s3-deployment"]
 deprecated: false
 type: application

--- a/charts/velero-s3-deployment/README.md
+++ b/charts/velero-s3-deployment/README.md
@@ -3,7 +3,7 @@
 # velero-s3-deployment
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/velero-s3-deployment)](https://artifacthub.io/packages/helm/radar-base/velero-s3-deployment)
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for Velero S3 deployment, this chart holds resources used by Velero with a deployment to mirror the local object storage to a remote object storage.
 

--- a/external/velero/values.yaml
+++ b/external/velero/values.yaml
@@ -150,6 +150,7 @@ metrics:
 kubectl:
   image:
     repository: docker.io/bitnami/kubectl
+    tag: 1.26.14-debian-11-r6
     # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:


### PR DESCRIPTION
**Description of the change**

Fixes BackfOffLimit Exceeded due to libc.so.6: version `GLIBC_2.33' not found, as mentioned upstream at https://github.com/vmware-tanzu/helm-charts/issues/550

**Benefits**

One will be able to deploy RADAR with Velero because it is currently not possible. This was an unnoticed regression.

**Possible drawbacks**

Uses a specific version of Debian but, because this is in an init container, it does not involve security issues in the long term.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/RADAR-base/RADAR-Kubernetes/pull/242#issuecomment-1997186331

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
