### PR TITLE
[data-dashboard-backend] Add helmchart for data dashboard backend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Before making a PR back to the `main`, ensure that the README of the chart is up
 helm-docs -s file --template-files=charts/_templates.gotmpl --template-files=DOCS.md.gotmpl --template-files=README.md.gotmpl --chart-search-root=charts
 ```
 
+or, when using Docker:
+
+```
+docker run --rm -v "$(pwd):/helm-docs" jnorwood/helm-docs:latest -s file --template-files=charts/_templates.gotmpl --template-files=DOCS.md.gotmpl --template-files=README.md.gotmpl --chart-search-root=charts
+```
+
 For general usage and instructions view the [helm-docs](https://github.com/norwoodj/helm-docs) README. Below is a short summary.
 
 In each chart directory use the following files to define what the README contents should be.

--- a/charts/data-dashboard-backend/.helmignore
+++ b/charts/data-dashboard-backend/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/data-dashboard-backend/Chart.yaml
+++ b/charts/data-dashboard-backend/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+appVersion: "0.1.0"
+name: data-dashboard-backend
+description: API for data in the data dashboard
+version: 0.1.6
+sources: ["https://github.com/thehyve/radar-data-dashboard-backend"]
+deprecated: false
+type: application
+home: "https://radar-base.org"
+maintainers:
+  - email: keyvan@thehyve.nl
+    name: Keyvan Hedayati
+    url: https://www.thehyve.nl
+  - email: nivethika@thehyve.nl
+    name: Nivethika Mahasivam
+    url: https://www.thehyve.nl/experts/nivethika-mahasivam
+  - email: bastiaan@thehyve.nl
+    name: Bastiaan de Graaf
+    url: https://www.thehyve.nl/experts/bastiaan-de-graaf
+  - email: pim@thehyve.nl
+    name: Pim van Nierop
+    url: https://www.thehyve.nl/experts/pim-van-nierop

--- a/charts/data-dashboard-backend/README.md
+++ b/charts/data-dashboard-backend/README.md
@@ -1,0 +1,69 @@
+
+
+# data-dashboard-backend
+
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+
+API for data in the data dashboard
+
+**Homepage:** <https://radar-base.org>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Keyvan Hedayati | <keyvan@thehyve.nl> | <https://www.thehyve.nl> |
+| Nivethika Mahasivam | <nivethika@thehyve.nl> | <https://www.thehyve.nl/experts/nivethika-mahasivam> |
+| Bastiaan de Graaf | <bastiaan@thehyve.nl> | <https://www.thehyve.nl/experts/bastiaan-de-graaf> |
+| Pim van Nierop | <pim@thehyve.nl> | <https://www.thehyve.nl/experts/pim-van-nierop> |
+
+## Source Code
+
+* <https://github.com/thehyve/radar-data-dashboard-backend>
+
+## Prerequisites
+* Kubernetes 1.22+
+* Kubectl 1.22+
+* Helm 3.1.0+
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| replicaCount | int | `2` | Number of replicas to deploy |
+| image.repository | string | `"ghcr.io/thehyve/radar-data-dashboard-backend"` | docker image repository |
+| image.pullPolicy | string | `"Always"` | image pull policy |
+| image.tag | string | `"v0.1.3-alpha"` |  |
+| imagePullSecrets | list | `[]` | Docker registry secret names as an array |
+| nameOverride | string | `""` | String to partially override fullname template with a string (will prepend the release name) |
+| fullnameOverride | string | `""` | String to fully override fullname template with a string |
+| podSecurityContext | object | `{}` | Configure pod's Security Context |
+| securityContext | object | `{}` | Configure container's Security Context |
+| service.type | string | `"ClusterIP"` | Kubernetes Service type |
+| service.port | int | `9000` | data-dashboard-backend port |
+| ingress.enabled | bool | `true` | Enable ingress controller resource |
+| ingress.className | string | `""` | Ingress class name |
+| ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
+| ingress.path | string | `"/api"` | Path within the url structure |
+| ingress.pathType | string | `"ImplementationSpecific"` |  |
+| ingress.hosts | list | `["localhost"]` | Hosts to accept requests from |
+| ingress.tls.secretName | string | `"radar-base-data-dashboard"` |  |
+| resources | object | `{}` |  |
+| autoscaling.enabled | bool | `false` | Enable horizontal autoscaling |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| nodeSelector | object | `{}` | Node labels for pod assignment |
+| tolerations | list | `[]` | Toleration labels for pod assignment |
+| affinity | object | `{}` | Affinity labels for pod assignment |
+| existingSecret | string | `""` |  |
+| javaOpts | string | `"-Xmx550m"` | Standard JAVA_OPTS that should be passed to this service |
+| managementPortal.url | string | `"http://management-portal:8080/managementportal"` | ManagementPortal URL |
+| managementPortal.clientId | string | `"radar_data_dashboard_backend"` | ManagementPortal OAuth 2.0 client ID, having grant type client_credentials |
+| managementPortal.clientSecret | string | `"secret"` | ManagementPortal OAuth 2.0 client secret |
+| path | string | `"/api"` |  |
+| jdbc.driver | string | `"org.postgresql.Driver"` | JDBC Driver to connect to the database. |
+| jdbc.url | string | `"jdbc:postgresql://postgresql:5432/data-dashboard"` | JDBC Connection url of the database. |
+| jdbc.user | string | `"radarbase"` | Username of the database |
+| jdbc.password | string | `"password"` | Password of the user |
+| jdbc.dialect | string | `"org.hibernate.dialect.PostgreSQLDialect"` | Hibernate dialect to use for JDBC Connection |

--- a/charts/data-dashboard-backend/README.md
+++ b/charts/data-dashboard-backend/README.md
@@ -30,10 +30,9 @@ API for data in the data dashboard
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| replicaCount | int | `2` | Number of replicas to deploy |
+| replicaCount | int | `1` | Number of replicas to deploy |
 | image.repository | string | `"ghcr.io/thehyve/radar-data-dashboard-backend"` | docker image repository |
 | image.pullPolicy | string | `"Always"` | image pull policy |
-| image.tag | string | `"v0.1.3-alpha"` |  |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override fullname template with a string (will prepend the release name) |
 | fullnameOverride | string | `""` | String to fully override fullname template with a string |
@@ -42,7 +41,7 @@ API for data in the data dashboard
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `9000` | data-dashboard-backend port |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
-| ingress.className | string | `""` | Ingress class name |
+| ingress.className | string | `"nginx"` | Ingress class name |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/api"` | Path within the url structure |
 | ingress.pathType | string | `"ImplementationSpecific"` |  |

--- a/charts/data-dashboard-backend/README.md.gotmpl
+++ b/charts/data-dashboard-backend/README.md.gotmpl
@@ -1,0 +1,18 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "common.prerequisites" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/charts/data-dashboard-backend/templates/NOTES.txt
+++ b/charts/data-dashboard-backend/templates/NOTES.txt
@@ -1,0 +1,20 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ $.Values.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "data-dashboard-backend.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "data-dashboard-backend.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "data-dashboard-backend.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "data-dashboard-backend.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:9000 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 9000:$CONTAINER_PORT
+{{- end }}

--- a/charts/data-dashboard-backend/templates/_helpers.tpl
+++ b/charts/data-dashboard-backend/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "data-dashboard-backend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "data-dashboard-backend.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "data-dashboard-backend.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Get the password secret.
+*/}}
+{{- define "data-dashboard-backend.secretName" -}}
+{{- if .Values.existingSecret }}
+    {{- printf "%s" .Values.existingSecret -}}
+{{- else -}}
+    {{- printf "%s" (include "data-dashboard-backend.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object should be created
+*/}}
+{{- define "data-dashboard-backend.createSecret" -}}
+{{- if .Values.existingSecret }}
+{{- else if .Values.existingSecret -}}
+{{- else -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "data-dashboard-backend.labels" -}}
+helm.sh/chart: {{ include "data-dashboard-backend.chart" . }}
+{{ include "data-dashboard-backend.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "data-dashboard-backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "data-dashboard-backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/data-dashboard-backend/templates/configmap.yaml
+++ b/charts/data-dashboard-backend/templates/configmap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "data-dashboard-backend.fullname" . }}
+  labels:
+    app: {{ template "data-dashboard-backend.name" . }}
+    chart: {{ template "data-dashboard-backend.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  dashboard.yml: |
+    service:
+      baseUri: http://0.0.0.0:9000{{ .Values.path }}
+      advertisedBaseUri: null
+      enableCors: true
+    auth:
+      managementPortal:
+        url: {{ .Values.managementPortal.url }}
+        clientId: {{ .Values.managementPortal.clientId }}
+        clientSecret: {{ .Values.managementPortal.clientSecret }}
+      jwtResourceName: res_data_dashboard_backend
+    database:
+      url: {{ .Values.jdbc.url }}
+      user: {{ .Values.jdbc.user }}
+      password: {{ .Values.jdbc.password }}
+      dialect: {{ .Values.jdbc.dialect }}

--- a/charts/data-dashboard-backend/templates/deployment.yaml
+++ b/charts/data-dashboard-backend/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "data-dashboard-backend.fullname" . }}
+  labels:
+    {{- include "data-dashboard-backend.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "data-dashboard-backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      labels:
+        {{- include "data-dashboard-backend.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "/etc/data-dashboard-backend/dashboard.yml"
+          env:
+          - name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "data-dashboard-backend.secretName" . }}
+                key: databaseUrl
+          - name: DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "data-dashboard-backend.secretName" . }}
+                key: databaseUser
+          - name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "data-dashboard-backend.secretName" . }}
+                key: databasePassword
+          ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+              httpHeaders:
+                - name: Accept
+                  value: application/json
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+              httpHeaders:
+                - name: Accept
+                  value: application/json
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/data-dashboard-backend/
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "data-dashboard-backend.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/data-dashboard-backend/templates/hpa.yaml
+++ b/charts/data-dashboard-backend/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "data-dashboard-backend.fullname" . }}
+  labels:
+    {{- include "data-dashboard-backend.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "data-dashboard-backend.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/data-dashboard-backend/templates/ingress.yaml
+++ b/charts/data-dashboard-backend/templates/ingress.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "data-dashboard-backend.fullname" . -}}
+{{- $path := .Values.ingress.path -}}
+{{- $hosts := .Values.ingress.hosts -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $pathType := .Values.ingress.pathType -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "data-dashboard-backend.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        {{- range .Values.ingress.hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: {{ $path | quote }}
+            {{- if and $pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/data-dashboard-backend/templates/secrets.yaml
+++ b/charts/data-dashboard-backend/templates/secrets.yaml
@@ -1,0 +1,13 @@
+{{- if (include "data-dashboard-backend.createSecret" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "data-dashboard-backend.fullname" . }}
+  labels:
+    {{- include "data-dashboard-backend.labels" . | nindent 4 }}
+type: Opaque
+data:
+  databaseUrl: {{ .Values.jdbc.url | b64enc | quote }}
+  databaseUser: {{ .Values.jdbc.user | b64enc | quote }}
+  databasePassword: {{ .Values.jdbc.password | b64enc | quote }}
+{{- end -}}

--- a/charts/data-dashboard-backend/templates/service.yaml
+++ b/charts/data-dashboard-backend/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "data-dashboard-backend.fullname" . }}
+  labels:
+    {{- include "data-dashboard-backend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "data-dashboard-backend.selectorLabels" . | nindent 4 }}

--- a/charts/data-dashboard-backend/templates/tests/test-connection.yaml
+++ b/charts/data-dashboard-backend/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "data-dashboard-backend.fullname" . }}-test-connection"
+  labels:
+    {{- include "data-dashboard-backend.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox:1.36
+      command: ['wget']
+      args: ['{{ include "data-dashboard-backend.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/data-dashboard-backend/values.yaml
+++ b/charts/data-dashboard-backend/values.yaml
@@ -1,0 +1,118 @@
+# Default values for data-dashboard-backend.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of replicas to deploy
+replicaCount: 2
+
+image:
+  # -- docker image repository
+  repository: ghcr.io/thehyve/radar-data-dashboard-backend
+  # -- image pull policy
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: v0.1.3-alpha
+
+# -- Docker registry secret names as an array
+imagePullSecrets: []
+
+# -- String to partially override fullname template with a string (will prepend the release name)
+nameOverride: ""
+# -- String to fully override fullname template with a string
+fullnameOverride: ""
+
+# -- Configure pod's Security Context
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- Configure container's Security Context
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  # -- Kubernetes Service type
+  type: ClusterIP
+  # -- data-dashboard-backend port
+  port: 9000
+
+ingress:
+  # -- Enable ingress controller resource
+  enabled: true
+  # -- Ingress class name
+  className: ""
+  # -- Annotations that define default ingress class, certificate issuer
+  # @default -- check values.yaml
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  # -- Path within the url structure
+  path: /api
+  pathType: ImplementationSpecific
+  # -- Hosts to accept requests from
+  hosts:
+    - localhost
+  tls:
+    secretName: radar-base-data-dashboard
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  # -- Enable horizontal autoscaling
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# -- Node labels for pod assignment
+nodeSelector: {}
+
+# -- Toleration labels for pod assignment
+tolerations: []
+
+# -- Affinity labels for pod assignment
+affinity: {}
+
+existingSecret: ""
+
+# -- Standard JAVA_OPTS that should be passed to this service
+javaOpts: "-Xmx550m"
+
+
+managementPortal:
+  # -- ManagementPortal URL
+  url: http://management-portal:8080/managementportal
+  # -- ManagementPortal OAuth 2.0 client ID, having grant type client_credentials
+  clientId: radar_data_dashboard_backend
+  # -- ManagementPortal OAuth 2.0 client secret
+  clientSecret: secret
+
+# Base path to use in application
+path: /api
+
+jdbc:
+  # -- JDBC Driver to connect to the database.
+  driver: org.postgresql.Driver
+  # -- JDBC Connection url of the database.
+  url: jdbc:postgresql://postgresql:5432/data-dashboard
+  # -- Username of the database
+  user: radarbase
+  # -- Password of the user
+  password: password
+  # -- Hibernate dialect to use for JDBC Connection
+  dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/charts/data-dashboard-backend/values.yaml
+++ b/charts/data-dashboard-backend/values.yaml
@@ -42,11 +42,10 @@ ingress:
   # -- Enable ingress controller resource
   enabled: true
   # -- Ingress class name
-  className: ""
+  className: nginx
   # -- Annotations that define default ingress class, certificate issuer
   # @default -- check values.yaml
   annotations:
-    kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
   # -- Path within the url structure
   path: /api

--- a/charts/data-dashboard-backend/values.yaml
+++ b/charts/data-dashboard-backend/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 # -- Number of replicas to deploy
-replicaCount: 2
+replicaCount: 1
 
 image:
   # -- docker image repository

--- a/charts/data-dashboard-backend/values.yaml
+++ b/charts/data-dashboard-backend/values.yaml
@@ -10,8 +10,6 @@ image:
   repository: ghcr.io/thehyve/radar-data-dashboard-backend
   # -- image pull policy
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: v0.1.3-alpha
 
 # -- Docker registry secret names as an array
 imagePullSecrets: []

--- a/charts/radar-output/templates/deployment.yaml
+++ b/charts/radar-output/templates/deployment.yaml
@@ -53,6 +53,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - radar-output-restructure
+            - radar-output-restructure
           args:
             - -F
             - /etc/radar-output/config.yaml

--- a/charts/radar-output/templates/deployment.yaml
+++ b/charts/radar-output/templates/deployment.yaml
@@ -53,7 +53,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - radar-output-restructure
-            - radar-output-restructure
           args:
             - -F
             - /etc/radar-output/config.yaml


### PR DESCRIPTION
# Background
We are in the process of implementing a new backend service named _data dashboard backend_ that acts as a common source for data present in the _timescale db_ storage.

# Change
This PR will:
- add the helm chart for this service named _data dashboard backend_
- update the README.md with instructions to run _helm-docs_ with docker 

# Checklist
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
