### PR TITLE
s3-proxy chart to appversion 2.2.0

### DIFF
--- a/charts/s3-proxy/Chart.yaml
+++ b/charts/s3-proxy/Chart.yaml
@@ -1,17 +1,17 @@
 apiVersion: v2
-appVersion: "2.0.0"
+appVersion: "2.2.0"
 description: A Helm chart for S3 Proxy. It uses https://hub.docker.com/r/andrewgaul/s3proxy to proxy S3 API requests to any supported cloud provider. For more examples see Find some example configurations at https://github.com/gaul/s3proxy/wiki/Storage-backend-examples.
 sources: ["https://github.com/gaul/s3proxy"]
 type: application
 home: "https://radar-base.org"
 name: s3-proxy
-version: 0.3.1
+version: 0.3.2
 maintainers:
   - email: keyvan@thehyve.nl
     name: Keyvan Hedayati
     url: https://www.thehyve.nl
-  - email: joris@thehyve.nl
-    name: Joris Borgdorff
+  - email: bastiaan@thehyve.nl
+    name: Bastiaan de Graaf
     url: https://www.thehyve.nl/experts/joris-borgdorff
   - email: nivethika@thehyve.nl
     name: Nivethika Mahasivam

--- a/charts/s3-proxy/README.md
+++ b/charts/s3-proxy/README.md
@@ -3,7 +3,7 @@
 # s3-proxy
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/s3-proxy)](https://artifacthub.io/packages/helm/radar-base/s3-proxy)
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.0](https://img.shields.io/badge/AppVersion-2.2.0-informational?style=flat-square)
 
 A Helm chart for S3 Proxy. It uses https://hub.docker.com/r/andrewgaul/s3proxy to proxy S3 API requests to any supported cloud provider. For more examples see Find some example configurations at https://github.com/gaul/s3proxy/wiki/Storage-backend-examples.
 
@@ -14,7 +14,7 @@ A Helm chart for S3 Proxy. It uses https://hub.docker.com/r/andrewgaul/s3proxy t
 | Name | Email | Url |
 | ---- | ------ | --- |
 | Keyvan Hedayati | <keyvan@thehyve.nl> | <https://www.thehyve.nl> |
-| Joris Borgdorff | <joris@thehyve.nl> | <https://www.thehyve.nl/experts/joris-borgdorff> |
+| Bastiaan de Graaf | <bastiaan@thehyve.nl> | <https://www.thehyve.nl/experts/joris-borgdorff> |
 | Nivethika Mahasivam | <nivethika@thehyve.nl> | <https://www.thehyve.nl/experts/nivethika-mahasivam> |
 
 ## Source Code
@@ -32,7 +32,7 @@ A Helm chart for S3 Proxy. It uses https://hub.docker.com/r/andrewgaul/s3proxy t
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of s3-proxy replicas to deploy |
 | image.repository | string | `"andrewgaul/s3proxy"` | s3-proxy image repository |
-| image.tag | string | `"sha-b5d090d"` | s3-proxy image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"sha-abc6d02"` | s3-proxy image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` | s3-proxy image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override s3-proxy.fullname template with a string (will prepend the release name) |

--- a/charts/s3-proxy/values.yaml
+++ b/charts/s3-proxy/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: andrewgaul/s3proxy
   # -- s3-proxy image tag (immutable tags are recommended)
   # Overrides the image tag whose default is the chart appVersion.
-  tag: sha-b5d090d
+  tag: sha-abc6d02
   # -- s3-proxy image pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
**Description of the change**

Update the s3-proxy chart to use the latest released image (2.2.0)

**Benefits**

more up to date images used

**Possible drawbacks**

none that I can think of

**Applicable issues**

NA

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
