### PR TITLE
[data-dashboard-backend] Add charts for data dashboard backend service

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ helm-docs -s file --template-files=charts/_templates.gotmpl --template-files=DOC
 or, when using Docker:
 
 ```
-docker run --rm -v "$(pwd):/helm-docs" jnorwood/helm-docs:latest -s file --template-files=charts/_templates.gotmpl --template-files=DOCS.md.gotmpl --template-files=README.md.gotmpl --chart-search-root=charts
+HELMDOCS_IMAGE=jnorwood/helm-docs:v1.8.1
+docker run --rm -v "$(pwd):/helm-docs" $HELMDOCS_IMAGE -s file --template-files=charts/_templates.gotmpl --template-files=DOCS.md.gotmpl --template-files=README.md.gotmpl --chart-search-root=charts
 ```
 
 For general usage and instructions view the [helm-docs](https://github.com/norwoodj/helm-docs) README. Below is a short summary.

--- a/charts/data-dashboard-backend/Chart.yaml
+++ b/charts/data-dashboard-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.1.0"
 name: data-dashboard-backend
 description: API for data in the data dashboard
-version: 0.1.6
+version: 0.1.8
 sources: ["https://github.com/thehyve/radar-data-dashboard-backend"]
 deprecated: false
 type: application

--- a/charts/data-dashboard-backend/README.md
+++ b/charts/data-dashboard-backend/README.md
@@ -2,7 +2,7 @@
 
 # data-dashboard-backend
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 API for data in the data dashboard
 
@@ -31,8 +31,9 @@ API for data in the data dashboard
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of replicas to deploy |
-| image.repository | string | `"ghcr.io/thehyve/radar-data-dashboard-backend"` | docker image repository |
+| image.repository | string | `"radarbase/radar-data-dashboard-backend"` | docker image repository |
 | image.pullPolicy | string | `"Always"` | image pull policy |
+| image.tag | string | `"latest"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override fullname template with a string (will prepend the release name) |
 | fullnameOverride | string | `""` | String to fully override fullname template with a string |
@@ -60,9 +61,9 @@ API for data in the data dashboard
 | managementPortal.url | string | `"http://management-portal:8080/managementportal"` | ManagementPortal URL |
 | managementPortal.clientId | string | `"radar_data_dashboard_backend"` | ManagementPortal OAuth 2.0 client ID, having grant type client_credentials |
 | managementPortal.clientSecret | string | `"secret"` | ManagementPortal OAuth 2.0 client secret |
-| path | string | `"/api"` |  |
+| path | string | `"/api"` | Base path to use in application |
 | jdbc.driver | string | `"org.postgresql.Driver"` | JDBC Driver to connect to the database. |
 | jdbc.url | string | `"jdbc:postgresql://postgresql:5432/data-dashboard"` | JDBC Connection url of the database. |
-| jdbc.user | string | `"radarbase"` | Username of the database |
-| jdbc.password | string | `"password"` | Password of the user |
+| jdbc.user | string | `"postgres"` | Username of the database |
+| jdbc.password | string | `"secret"` | Password of the user |
 | jdbc.dialect | string | `"org.hibernate.dialect.PostgreSQLDialect"` | Hibernate dialect to use for JDBC Connection |

--- a/charts/data-dashboard-backend/templates/configmap.yaml
+++ b/charts/data-dashboard-backend/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
         url: {{ .Values.managementPortal.url }}
         clientId: {{ .Values.managementPortal.clientId }}
         clientSecret: {{ .Values.managementPortal.clientSecret }}
-      jwtResourceName: res_data_dashboard_backend
+      jwtResourceName: {{ .Values.jwtResourceName }}
     database:
       url: {{ .Values.jdbc.url }}
       user: {{ .Values.jdbc.user }}

--- a/charts/data-dashboard-backend/templates/deployment.yaml
+++ b/charts/data-dashboard-backend/templates/deployment.yaml
@@ -58,14 +58,14 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /api/health
+              path: {{ .Values.path }}/health
               port: http
               httpHeaders:
                 - name: Accept
                   value: application/json
           readinessProbe:
             httpGet:
-              path: /api/health
+              path: {{ .Values.path }}/health
               port: http
               httpHeaders:
                 - name: Accept

--- a/charts/data-dashboard-backend/values.yaml
+++ b/charts/data-dashboard-backend/values.yaml
@@ -7,9 +7,11 @@ replicaCount: 1
 
 image:
   # -- docker image repository
-  repository: ghcr.io/thehyve/radar-data-dashboard-backend
+  repository: radarbase/radar-data-dashboard-backend
   # -- image pull policy
   pullPolicy: Always
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: latest
 
 # -- Docker registry secret names as an array
 imagePullSecrets: []
@@ -99,7 +101,7 @@ managementPortal:
   # -- ManagementPortal OAuth 2.0 client secret
   clientSecret: secret
 
-# Base path to use in application
+# -- Base path to use in application
 path: /api
 
 jdbc:
@@ -108,8 +110,8 @@ jdbc:
   # -- JDBC Connection url of the database.
   url: jdbc:postgresql://postgresql:5432/data-dashboard
   # -- Username of the database
-  user: radarbase
+  user: postgres
   # -- Password of the user
-  password: password
+  password: secret
   # -- Hibernate dialect to use for JDBC Connection
   dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.0.0"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 1.1.4
+version: 1.1.5
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -3,7 +3,7 @@
 # management-portal
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -593,3 +593,15 @@ oauth_clients:
     authorized_grant_types:
       - client_credentials
     access_token_validity: 900
+
+  radar_data_dashboard_backend:
+    enable: false
+    resource_ids:
+      - res_DataDashboardAPI
+    client_secret: ""
+    scope:
+      - MEASUREMENT.READ
+    authorized_grant_types:
+      - authorization_code
+      - refresh_token
+    access_token_validity: 900


### PR DESCRIPTION
**Description of the change**

Data dashboard backend is a new service that exposes data from the _observations_ table in _timescaledb_ database (provisioned by KSQLDB service) to frontend/mobile applications. This PR will improve the helm chart for this service.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
