### PR TITLE
Set image version of data-dashboard-backend to 0.1.2-alpha

### DIFF
--- a/charts/data-dashboard-backend/values.yaml
+++ b/charts/data-dashboard-backend/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- image pull policy
   pullPolicy: Always
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: latest
+  tag: 0.1.2-alpha
 
 # -- Docker registry secret names as an array
 imagePullSecrets: []


### PR DESCRIPTION
This PR will change the docker image tag `latest` to the defined version `0.1.2-alpha`.