### PR TITLE
[cert-manager-letsencrypt] Allow to override ingress class for HTTP solver

### DIFF
--- a/charts/cert-manager-letsencrypt/Chart.yaml
+++ b/charts/cert-manager-letsencrypt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for a cert-manager ClusterIssuer for letsencrypt. Requires the cert-manager release to be activated.
 name: cert-manager-letsencrypt
-version: 0.1.1
+version: 0.1.2
 sources: ["https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/cert-manager-letsencrypt"]
 deprecated: false
 type: application

--- a/charts/cert-manager-letsencrypt/README.md
+++ b/charts/cert-manager-letsencrypt/README.md
@@ -3,7 +3,7 @@
 # cert-manager-letsencrypt
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cert-manager-letsencrypt)](https://artifacthub.io/packages/helm/radar-base/cert-manager-letsencrypt)
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for a cert-manager ClusterIssuer for letsencrypt. Requires the cert-manager release to be activated.
 
@@ -34,3 +34,5 @@ A Helm chart for a cert-manager ClusterIssuer for letsencrypt. Requires the cert
 | httpIssuer.enabled | bool | `true` | Enable the letsencrypt HTTP issuer |
 | httpIssuer.environment | string | `"production"` | Environment to use. Either staging or production |
 | httpIssuer.privateSecretRef | string | `"letsencrypt-prod"` | Secret to store letsencrypt certificate data in |
+| httpIssuer.ingressMatchMethod | string | `"class"` | How to match ingress that's supposed to be used. Can be class, ingressClassName, name |
+| httpIssuer.ingressMatchValue | string | `"nginx"` | Ingress class/name to use |

--- a/charts/cert-manager-letsencrypt/templates/clusterissuer.yaml
+++ b/charts/cert-manager-letsencrypt/templates/clusterissuer.yaml
@@ -23,5 +23,5 @@ spec:
     solvers:
       - http01:
          ingress:
-           class: nginx
+           {{ .Values.httpIssuer.ingressMatchMethod }}: {{ .Values.httpIssuer.ingressMatchValue }}
 {{- end -}}

--- a/charts/cert-manager-letsencrypt/values.yaml
+++ b/charts/cert-manager-letsencrypt/values.yaml
@@ -17,3 +17,7 @@ httpIssuer:
   environment: production
   # -- Secret to store letsencrypt certificate data in
   privateSecretRef: letsencrypt-prod
+  # -- How to match ingress that's supposed to be used. Can be class, ingressClassName, name
+  ingressMatchMethod: class
+  # -- Ingress class/name to use
+  ingressMatchValue: nginx


### PR DESCRIPTION
**Description of the change**

Allow to configure ingress class for HTTP-01 solver for certmanager (letsencrypt)

**Benefits**

Allows to use different than default ingress in cases where there are multiple in the cluster and you need to handle certificates for the non-default one.

Also handles the case, where you're using the ingressClassNamre matching on your ingress instead of the legacy annotation way. The default is set for the legacy approach.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
