### PR TITLE
[radar-integration] Fix MP url

### DIFF
--- a/charts/radar-integration/Chart.yaml
+++ b/charts/radar-integration/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0.4"
 description: A Helm chart for RADAR-Base REDCap survey integration application.
 name: radar-integration
-version: 0.5.2
+version: 0.5.3
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-integration

--- a/charts/radar-integration/README.md
+++ b/charts/radar-integration/README.md
@@ -3,7 +3,7 @@
 # radar-integration
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-integration)](https://artifacthub.io/packages/helm/radar-base/radar-integration)
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.4](https://img.shields.io/badge/AppVersion-1.0.4-informational?style=flat-square)
+![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.4](https://img.shields.io/badge/AppVersion-1.0.4-informational?style=flat-square)
 
 A Helm chart for RADAR-Base REDCap survey integration application.
 
@@ -69,7 +69,7 @@ A Helm chart for RADAR-Base REDCap survey integration application.
 | networkpolicy | object | check `values.yaml` | Network policy defines who can access this application and who this applications has access to |
 | oauth_client_id | string | `"radar_redcap_integrator"` | OAuth2 clientId used by the webApp for making requests |
 | oauth_client_secret | string | `"secret"` | OAuth2 client secret |
-| managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of the Management Portal |
+| managementportal_url | string | `"http://management-portal:8080/managementportal/"` | URL of the Management Portal. Make sure to include the trailing slash |
 | projects[0].redcap_info.url | string | `""` | URL pointing REDCap instance |
 | projects[0].redcap_info.project_id | string | `""` | REDCap project identifier |
 | projects[0].redcap_info.api_path | string | `"/api/"` | Redcap relative api path |

--- a/charts/radar-integration/values.yaml
+++ b/charts/radar-integration/values.yaml
@@ -166,8 +166,8 @@ networkpolicy:
 oauth_client_id: radar_redcap_integrator
 # -- OAuth2 client secret
 oauth_client_secret: secret
-# -- URL of the Management Portal
-managementportal_url: http://management-portal:8080/managementportal
+# -- URL of the Management Portal. Make sure to include the trailing slash
+managementportal_url: http://management-portal:8080/managementportal/
 
 projects:
   - redcap_info:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of maintainers might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

MP url was incorrect in the redcap integration helm chart (did not contain the trailing /). This updates the mp url.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
