### PR TITLE
Fix names of KAFKA_NUM_PARTITIONS and KAFKA_NUM_REPLICATION of RADAR-Schemas

### DIFF
--- a/charts/catalog-server/Chart.yaml
+++ b/charts/catalog-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.8"
 description: A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 name: catalog-server
-version: 0.5.3
+version: 0.6.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/catalog-server

--- a/charts/catalog-server/README.md
+++ b/charts/catalog-server/README.md
@@ -3,7 +3,7 @@
 # catalog-server
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/catalog-server)](https://artifacthub.io/packages/helm/radar-base/catalog-server)
 
-![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.8](https://img.shields.io/badge/AppVersion-0.8.8-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.8](https://img.shields.io/badge/AppVersion-0.8.8-informational?style=flat-square)
 
 A Helm chart for RADAR-base catalogue server. This application creates RADAR-base topics in Kafka, registers schemas in Schema Registry and keeps a catalog of available source types.
 
@@ -65,7 +65,9 @@ A Helm chart for RADAR-base catalogue server. This application creates RADAR-bas
 | readinessProbe.successThreshold | int | `1` | Success threshold for readinessProbe |
 | readinessProbe.failureThreshold | int | `3` | Failure threshold for readinessProbe |
 | networkpolicy | object | check `values.yaml` | Network policy defines who can access this application and who this applications has access to |
-| kafka_num_brokers | int | `3` | number of Kafka brokers to look for |
+| kafka_num_brokers | int | `3` | Number of deployed Kafka brokers |
+| kafka_num_replication | int | `3` | Number of Kafka replicates (may not be lower than kafka_num_brokers) |
+| kafka_num_partitions | int | `3` | Number of Kafka data partitions |
 | kafka | string | `"cp-kafka-headless:9092"` | URI of Kafka brokers |
 | schema_registry | string | `"http://cp-schema-registry:8081"` | URL of the confluent schema registry |
 | kafkaProperties | object | `{"security_protocol":"PLAINTEXT"}` | Additional kafka properties such as security config. The template replaces `_` with `.` in keys so property keys can be specified using `_` instead of `.`. For example `security_protocol` is same as `security.protocol` kafka config. |

--- a/charts/catalog-server/templates/deployment.yaml
+++ b/charts/catalog-server/templates/deployment.yaml
@@ -61,10 +61,10 @@ spec:
           value: "{{ .Values.schema_registry }}"
         - name: KAFKA_NUM_BROKERS
           value: "{{ .Values.kafka_num_brokers }}"
-        - name: RADAR_NUM_PARTITIONS
-          value: "3"
-        - name: RADAR_NUM_REPLICATION_FACTOR
-          value: "3"
+        - name: KAFKA_NUM_REPLICATION
+          value: "{{ .Values.kafka_num_replication }}"
+        - name: KAFKA_NUM_PARTITIONS
+          value: "{{ .Values.kafka_num_partitions }}"
         - name: CONFIG_PATH
           value: /etc/radar-schemas-tools/config.yaml
         {{- if .Values.cc.enabled }}

--- a/charts/catalog-server/values.yaml
+++ b/charts/catalog-server/values.yaml
@@ -176,8 +176,12 @@ networkpolicy:
         matchLabels:
           app.kubernetes.io/name: cp-schema-registry
 
-# -- number of Kafka brokers to look for
+# -- Number of deployed Kafka brokers
 kafka_num_brokers: 3
+# -- Number of Kafka replicates (may not be lower than kafka_num_brokers)
+kafka_num_replication: 3
+# -- Number of Kafka data partitions
+kafka_num_partitions: 3
 # -- URI of Kafka brokers
 kafka: cp-kafka-headless:9092
 # -- URL of the confluent schema registry


### PR DESCRIPTION
# Problem
The helm chart of _catalog-server_ does not correctly reference two env vars defined in RADAR-Schemas. The `KAFKA_NUM_REPLICATION` and `KAFKA_NUM_PARTITIONS` of RADAR-Schemas are referenced as `RADAR_NUM_REPLICATION_FACTOR` and `RADAR_NUM_PARTITIONS`, respectively. From the RADAR-Schemas Dockefile:

```
ENV KAFKA_SCHEMA_REGISTRY=http://schema-registry-1:8081 \
    ...
    KAFKA_NUM_PARTITIONS=3 \
    KAFKA_NUM_REPLICATION=3 \
    KAFKA_NUM_BROKERS=3 \
    ...
```



This breaks the mechanism where the _kafka_num_brokers_ can set the number of brokers because the KAFKA_NUM_REPLICATION is not controller accordingly.

# Fix
This PR will:
- fix the env var names. 
- externalize the values for `KAFKA_NUM_REPLICATION` and `KAFKA_NUM_PARTITIONS` to the values.yaml file.