### PR TITLE
Add gitattribute to help with correct helm-docs formatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
**Description of the change**

Add a gitattribute to ensure automatic normalization of line endings for new files.

**Benefits**

Prevent files being checked in with the wrong line-endings, so that everyone can count on consistent line-endings in the whole repo.

**Possible drawbacks**

-

**Applicable issues**

-

**Additional information**

This was done in an effort to improve the contributor experience on windows, as troubles with lin-endings there cause failing CI jobs. It is a part of [this step by step guide to changing the line-endings in the repo locally](https://stackoverflow.com/a/13154031).

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
