### PR TITLE
[radar-gateway] Fixed default HPA memory

### DIFF
--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.7.1"
 description: A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 name: radar-gateway
-version: 1.1.5
+version: 1.1.6
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-gateway

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -72,7 +72,7 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | hpa.enabled | bool | `true` | Enable HPA |
 | hpa.maxReplicas | string | `"5"` | Maximum number of replicas |
 | hpa.targetCPU | string | `"50"` | Target CPU utilization percentage |
-| hpa.targetMemory | int | `50` | Target Memory utilization percentage |
+| hpa.targetMemory | int | `85` | Target Memory utilization percentage |
 | managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of the management portal application |
 | schemaRegistry | string | `"http://cp-schema-registry:8081"` | Schema Registry URL |
 | max_requests | int | `1000` | Not used. To be confirmed |

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -3,7 +3,7 @@
 # radar-gateway
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-gateway)](https://artifacthub.io/packages/helm/radar-base/radar-gateway)
 
-![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
+![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
 
 A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 
@@ -72,7 +72,7 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | hpa.enabled | bool | `true` | Enable HPA |
 | hpa.maxReplicas | string | `"5"` | Maximum number of replicas |
 | hpa.targetCPU | string | `"50"` | Target CPU utilization percentage |
-| hpa.targetMemory | string | `"1Gi"` | Target Memory utilization percentage |
+| hpa.targetMemory | int | `50` | Target Memory utilization percentage |
 | managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of the management portal application |
 | schemaRegistry | string | `"http://cp-schema-registry:8081"` | Schema Registry URL |
 | max_requests | int | `1000` | Not used. To be confirmed |

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -191,7 +191,7 @@ hpa:
   # -- Target CPU utilization percentage
   targetCPU: "50"
   # -- Target Memory utilization percentage
-  targetMemory: "1Gi"
+  targetMemory: 50
 
 # -- URL of the management portal application
 managementportal_url: http://management-portal:8080/managementportal

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -191,7 +191,7 @@ hpa:
   # -- Target CPU utilization percentage
   targetCPU: "50"
   # -- Target Memory utilization percentage
-  targetMemory: 50
+  targetMemory: 85
 
 # -- URL of the management portal application
 managementportal_url: http://management-portal:8080/managementportal


### PR DESCRIPTION
It seems like memory value should be percentage value instead of bytes.