### PR TITLE
[radar-appserver] Add SMTP server configuration to send notifications via email

### DIFF
--- a/charts/radar-appserver/Chart.yaml
+++ b/charts/radar-appserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.4.1"
 description: A Helm chart for the backend application of RADAR-base Appserver
 name: radar-appserver
-version: 0.2.2
+version: 0.3.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-appserver

--- a/charts/radar-appserver/README.md
+++ b/charts/radar-appserver/README.md
@@ -3,7 +3,7 @@
 # radar-appserver
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-appserver)](https://artifacthub.io/packages/helm/radar-base/radar-appserver)
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.1](https://img.shields.io/badge/AppVersion-2.4.1-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Appserver
 
@@ -84,3 +84,11 @@ A Helm chart for the backend application of RADAR-base Appserver
 | public_key_endpoints | string | `nil` |  |
 | google_application_credentials | string | `""` | Google credentials containing FCM server key, etc. |
 | github_client_token | string | `""` | Github client token which is used for authenticating requests |
+| smtp.enabled | bool | `false` | set to true, if sending of notifications via email should be enabled. |
+| smtp.host | string | `"smtp"` | Hostname of the SMTP server |
+| smtp.port | int | `25` | Port of the SMTP server |
+| smtp.username | string | `"username"` | Username of the SMTP server |
+| smtp.password | string | `"secret"` | Password of the SMTP server |
+| smtp.from | string | `"noreply@example.com"` | Email address which should be used to send activation emails |
+| smtp.starttls | bool | `false` | set to true,if TTLS should be enabled |
+| smtp.auth | bool | `true` | set to true, if the account should be authenticated before sending emails |

--- a/charts/radar-appserver/templates/deployment.yaml
+++ b/charts/radar-appserver/templates/deployment.yaml
@@ -83,16 +83,16 @@ spec:
                 key: githubClientToken
           {{- if .Values.smtp.enabled}}
           - name: RADAR_NOTIFICATION_EMAIL_ENABLED
-            value: {{ .Values.smtp.enabled }}
+            value: "{{ .Values.smtp.enabled }}"
           - name: RADAR_NOTIFICATION_EMAIL_FROM
-            value: {{ .Values.smtp.from }}
+            value: "{{ .Values.smtp.from }}"
           - name: SPRING_MAIL_HOST
-            value: {{ .Values.smtp.host }}
+            value: "{{ .Values.smtp.host }}"
           - name: SPRING_MAIL_PORT
             value: {{ .Values.smtp.port }}
           - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH
-            value: {{ .Values.smtp.auth }}
-              {{- if .Values.smtp.auth }}
+            value: "{{ .Values.smtp.auth }}"
+            {{- if .Values.smtp.auth }}
           - name: SPRING_MAIL_USERNAME
             valueFrom:
               secretKeyRef:
@@ -103,9 +103,9 @@ spec:
               secretKeyRef:
                 name: {{ template "radar-appserver.secretName" . }}
                 key: smtpPassword
-              {{- end }}
+            {{- end }}
           - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE
-            value: {{ .Values.smtp.starttls }}
+            value: "{{ .Values.smtp.starttls }}"
           {{- end }}
           {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 10 }}

--- a/charts/radar-appserver/templates/deployment.yaml
+++ b/charts/radar-appserver/templates/deployment.yaml
@@ -81,6 +81,32 @@ spec:
               secretKeyRef:
                 name: {{ template "radar-appserver.secretName" . }}
                 key: githubClientToken
+          {{- if .Values.smtp.enabled}}
+          - name: NOTIFICATION_EMAIL_ENABLED
+            value: {{ .Values.smtp.enabled }}
+          - name: NOTIFICATION_EMAIL_FROM
+            value: {{ .Values.smtp.from }}
+          - name: SPRING_MAIL_HOST
+            value: {{ .Values.smtp.host }}
+          - name: SPRING_MAIL_PORT
+            value: {{ .Values.smtp.port }}
+          - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH
+            value: {{ .Values.smtp.auth }}
+              {{- if .Values.smtp.auth }}
+          - name: SPRING_MAIL_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "radar-appserver.secretName" . }}
+                key: smtpUsername
+          - name: SPRING_MAIL_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "radar-appserver.secretName" . }}
+                key: smtpPassword
+              {{- end }}
+          - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE
+            value: {{ .Values.smtp.starttls }}
+          {{- end }}
           {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/radar-appserver/templates/deployment.yaml
+++ b/charts/radar-appserver/templates/deployment.yaml
@@ -82,9 +82,9 @@ spec:
                 name: {{ template "radar-appserver.secretName" . }}
                 key: githubClientToken
           {{- if .Values.smtp.enabled}}
-          - name: NOTIFICATION_EMAIL_ENABLED
+          - name: RADAR_NOTIFICATION_EMAIL_ENABLED
             value: {{ .Values.smtp.enabled }}
-          - name: NOTIFICATION_EMAIL_FROM
+          - name: RADAR_NOTIFICATION_EMAIL_FROM
             value: {{ .Values.smtp.from }}
           - name: SPRING_MAIL_HOST
             value: {{ .Values.smtp.host }}

--- a/charts/radar-appserver/templates/deployment.yaml
+++ b/charts/radar-appserver/templates/deployment.yaml
@@ -81,18 +81,20 @@ spec:
               secretKeyRef:
                 name: {{ template "radar-appserver.secretName" . }}
                 key: githubClientToken
-          {{- if .Values.smtp.enabled}}
+          {{- if .Values.smtp.enabled }}
           - name: RADAR_NOTIFICATION_EMAIL_ENABLED
-            value: "{{ .Values.smtp.enabled }}"
+            value: {{ .Values.smtp.enabled | quote }}
           - name: RADAR_NOTIFICATION_EMAIL_FROM
-            value: "{{ .Values.smtp.from }}"
+            value: {{ .Values.smtp.from }}
           - name: SPRING_MAIL_HOST
             value: "{{ .Values.smtp.host }}"
           - name: SPRING_MAIL_PORT
-            value: {{ .Values.smtp.port }}
+            value: {{ .Values.smtp.port | quote }}
+          - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE
+            value: {{ .Values.smtp.starttls | quote }}
           - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH
-            value: "{{ .Values.smtp.auth }}"
-            {{- if .Values.smtp.auth }}
+            value: {{ .Values.smtp.auth | quote }}
+            {{ if .Values.smtp.auth }}
           - name: SPRING_MAIL_USERNAME
             valueFrom:
               secretKeyRef:
@@ -104,8 +106,6 @@ spec:
                 name: {{ template "radar-appserver.secretName" . }}
                 key: smtpPassword
             {{- end }}
-          - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE
-            value: "{{ .Values.smtp.starttls }}"
           {{- end }}
           {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 10 }}

--- a/charts/radar-appserver/templates/secrets.yaml
+++ b/charts/radar-appserver/templates/secrets.yaml
@@ -13,4 +13,8 @@ data:
   databasePassword: {{ .Values.postgres.password | b64enc | quote }}
   githubClientToken: {{ .Values.github_client_token | b64enc | quote }}
   firebaseAdminSdkKey: {{ .Values.google_application_credentials | b64enc | quote }}
+  {{- if and .Values.smtp.enabled .Values.smtp.auth }}
+  smtpUsername: {{ .Values.smtp.username | b64enc | quote }}
+  smtpPassword: {{ .Values.smtp.password | b64enc | quote }}
+  {{ end }}
 {{- end -}}

--- a/charts/radar-appserver/values.yaml
+++ b/charts/radar-appserver/values.yaml
@@ -213,3 +213,21 @@ google_application_credentials: ""
 
 # -- Github client token which is used for authenticating requests
 github_client_token: ""
+
+smtp:
+  # -- set to true, if sending of notifications via email should be enabled.
+  enabled: false
+  # -- Hostname of the SMTP server
+  host: smtp
+  # -- Port of the SMTP server
+  port: 25
+  # -- Username of the SMTP server
+  username: username
+  # -- Password of the SMTP server
+  password: secret
+  # -- Email address which should be used to send activation emails
+  from: noreply@example.com
+  # -- set to true,if TTLS should be enabled
+  starttls: false
+  # -- set to true, if the account should be authenticated before sending emails
+  auth: true


### PR DESCRIPTION
**Description of the change**

This PR will pass SMTP connection credentials to the Appserver application. When value `smtp.enabled=true`, Appserver will send notifications via email alongside push notifications.

**Note**

This feature depends on a new version of Appserver that is not yet available. The version bump will happen when new app version exists.


**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
