### PR TITLE
[management-portal] Support setting AAL2 and identityserver login url

### DIFF
--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "2.0.0"
+appVersion: "2.1.1"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 1.1.7
+version: 1.1.8
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -3,7 +3,7 @@
 # management-portal
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
-![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 
@@ -33,7 +33,7 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 |-----|------|---------|-------------|
 | replicaCount | int | `1` | Number of Management Portal replicas to deploy |
 | image.repository | string | `"radarbase/management-portal"` | Management Portal image repository |
-| image.tag | string | `"2.0.0"` | Management Portal image tag (immutable tags are recommended) |
+| image.tag | string | `nil` | Management Portal image tag (immutable tags are recommended) |
 | image.pullPolicy | string | `"IfNotPresent"` | Management Portal image pull policy |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
 | nameOverride | string | `""` | String to partially override management-portal.fullname template with a string (will prepend the release name) |
@@ -84,6 +84,7 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 | identity_server.admin_email | string | `"admin@example.com"` | The admin email to link to the admin service account. This account should only be used to set up admin-users |
 | identity_server.server_url | string | `"https://my.example-domain.net/kratos"` | The publicly accessible server URL for the IDP |
 | identity_server.server_admin_url | string | `"http://kratos-admin"` | The admin server URL for the IDP. Only needs to be accessible from inside the cluster where the managementportal resides |
+| identity_server.login_url | string | `"https://my.example-domain.net/kratos-ui"` | The login URL for the IDP. Needs to be publicly accessible |
 | managementportal.catalogue_server_enable_auto_import | bool | `false` | set to true, if automatic source-type import from catalogue server should be enabled |
 | managementportal.common_privacy_policy_url | string | `"http://info.thehyve.nl/radar-cns-privacy-policy"` | Override with a publicly resolvable url of the privacy-policy url for your set-up. This can be overridden on a project basis as well. |
 | managementportal.oauth_checking_key_aliases_0 | string | `"radarbase-managementportal-ec"` | Keystore alias to sign JWT tokens from Management Portal |

--- a/charts/management-portal/templates/deployment.yaml
+++ b/charts/management-portal/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           - name: SPRING_PROFILES_ACTIVE
@@ -82,12 +82,16 @@ spec:
             value: /secrets/oauth_client_details.csv
           - name: MANAGEMENTPORTAL_CATALOGUE_SERVER_ENABLE_AUTO_IMPORT
             value: "{{ .Values.managementportal.catalogue_server_enable_auto_import }}"
+          - name: MANAGEMENTPORTAL_OAUTH_REQUIRE_AAL2
+            value: "{{ .Values.managementportal.oauth_require_aal2 }}"
           - name: MANAGEMENTPORTAL_CATALOGUE_SERVER_SERVER_URL
             value: http://{{ .Values.catalogue_server }}:9010/source-types
           - name: MANAGEMENTPORTAL_IDENTITY_SERVER_ADMIN_EMAIL
             value: {{ .Values.identity_server.admin_email }}
           - name: MANAGEMENTPORTAL_IDENTITY_SERVER_SERVER_URL
             value: {{ .Values.identity_server.server_url }}
+          - name: MANAGEMENTPORTAL_IDENTITY_SERVER_LOGIN_URL
+            value: {{ .Values.identity_server.login_url }}
           - name: MANAGEMENTPORTAL_IDENTITY_SERVER_SERVER_ADMIN_URL
             value: {{ .Values.identity_server.server_admin_url }}
           - name: MANAGEMENTPORTAL_COMMON_ADMIN_PASSWORD

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -9,7 +9,7 @@ image:
   # -- Management Portal image repository
   repository: radarbase/management-portal
   # -- Management Portal image tag (immutable tags are recommended)
-  tag: 2.0.0
+  tag:
   # -- Management Portal image pull policy
   pullPolicy: IfNotPresent
 
@@ -272,6 +272,8 @@ identity_server:
   server_url: https://my.example-domain.net/kratos
   # -- The admin server URL for the IDP. Only needs to be accessible from inside the cluster where the managementportal resides
   server_admin_url: http://kratos-admin
+  # -- The login URL for the IDP. Needs to be publicly accessible
+  login_url: https://my.example-domain.net/kratos-ui
 
 managementportal:
   # -- set to true, if automatic source-type import from catalogue server should be enabled


### PR DESCRIPTION
**Description of the change**

Add support for the configuration of AAL2 and the identityserver login url to managementportal.

**Benefits**

we can set these values

**Possible drawbacks**

The development of MP is currently very active, and these variables may change relatively soon

**Applicable issues**

-

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
