### PR TITLE
[radar-rest-sources-authorizer] Use default authUrl

### DIFF
--- a/charts/radar-rest-sources-authorizer/Chart.yaml
+++ b/charts/radar-rest-sources-authorizer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.2"
 description: A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 name: radar-rest-sources-authorizer
-version: 1.1.4
+version: 1.1.5
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-authorizer

--- a/charts/radar-rest-sources-authorizer/README.md
+++ b/charts/radar-rest-sources-authorizer/README.md
@@ -3,7 +3,7 @@
 # radar-rest-sources-authorizer
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-rest-sources-authorizer)](https://artifacthub.io/packages/helm/radar-base/radar-rest-sources-authorizer)
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.2](https://img.shields.io/badge/AppVersion-4.4.2-informational?style=flat-square)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.2](https://img.shields.io/badge/AppVersion-4.4.2-informational?style=flat-square)
 
 A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 
@@ -71,4 +71,4 @@ A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer
 | networkpolicy | object | check `values.yaml` | Network policy defines who can access this application and who this applications has access to |
 | clientId | string | `"radar_rest_sources_authorizer"` | OAuth2 client id of the application registered in Management Portal. It is assumed that this is a public client with empty client secret. |
 | serverName | string | `"localhost"` | Domain name of the server |
-| authUrl | string | `"localhost/managementportal/oauth"` | Authorization URL of the IDP |
+| authUrl | string | `nil` | Custom authorization URL of the IDP; needed when deviating from https://<serverName>/managementportal/oauth. |

--- a/charts/radar-rest-sources-authorizer/templates/deployment.yaml
+++ b/charts/radar-rest-sources-authorizer/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           - name: AUTH_CALLBACK_URL
             value: https://{{ .Values.serverName }}/rest-sources/authorizer/login
           - name: AUTH_URI
-            value: https://{{ .Values.authUrl }}
+            value: {{ default (printf "https://%s/managementportal/oauth" .Values.serverName) .Values.authUrl }}
           {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/radar-rest-sources-authorizer/values.yaml
+++ b/charts/radar-rest-sources-authorizer/values.yaml
@@ -155,5 +155,5 @@ networkpolicy:
 clientId: radar_rest_sources_authorizer
 # -- Domain name of the server
 serverName: localhost
-# -- Authorization URL of the IDP
-authUrl: localhost/managementportal/oauth
+# -- Custom authorization URL of the IDP; needed when deviating from https://<serverName>/managementportal/oauth.
+authUrl:


### PR DESCRIPTION
# Problem
By default, the rest-sources-authorizer would use _localhost/managementportal/auth_ as authorization URL.

# Solution
The application will use _https://serverName/managementportal/oauth_ as default authUrl. A custom authUrl can be provided via the _values.md_ file.