### PR TITLE
[management-portal] Impl. default values for Ory URLs

### DIFF
--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.1.1"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 1.1.8
+version: 1.1.10
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -3,7 +3,7 @@
 # management-portal
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
-![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
+![Version: 1.1.10](https://img.shields.io/badge/Version-1.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.1](https://img.shields.io/badge/AppVersion-2.1.1-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 
@@ -82,9 +82,9 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 | server_name | string | `"localhost"` | domain name of the server |
 | catalogue_server | string | `"catalog-server"` | Hostname of the catalogue-server |
 | identity_server.admin_email | string | `"admin@example.com"` | The admin email to link to the admin service account. This account should only be used to set up admin-users |
-| identity_server.server_url | string | `"https://my.example-domain.net/kratos"` | The publicly accessible server URL for the IDP |
-| identity_server.server_admin_url | string | `"http://kratos-admin"` | The admin server URL for the IDP. Only needs to be accessible from inside the cluster where the managementportal resides |
-| identity_server.login_url | string | `"https://my.example-domain.net/kratos-ui"` | The login URL for the IDP. Needs to be publicly accessible |
+| identity_server.server_url | string | `nil` | The publicly accessible server URL for the IDP; needed when deviating from https://server_name/kratos |
+| identity_server.server_admin_url | string | `"http://kratos-admin"` | The admin server URL for the IDP used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides |
+| identity_server.login_url | string | `nil` | Needs to be publicly accessible |
 | managementportal.catalogue_server_enable_auto_import | bool | `false` | set to true, if automatic source-type import from catalogue server should be enabled |
 | managementportal.common_privacy_policy_url | string | `"http://info.thehyve.nl/radar-cns-privacy-policy"` | Override with a publicly resolvable url of the privacy-policy url for your set-up. This can be overridden on a project basis as well. |
 | managementportal.oauth_checking_key_aliases_0 | string | `"radarbase-managementportal-ec"` | Keystore alias to sign JWT tokens from Management Portal |

--- a/charts/management-portal/templates/deployment.yaml
+++ b/charts/management-portal/templates/deployment.yaml
@@ -89,9 +89,9 @@ spec:
           - name: MANAGEMENTPORTAL_IDENTITY_SERVER_ADMIN_EMAIL
             value: {{ .Values.identity_server.admin_email }}
           - name: MANAGEMENTPORTAL_IDENTITY_SERVER_SERVER_URL
-            value: {{ .Values.identity_server.server_url }}
+            value: {{ default (printf "https://%s/kratos" .Values.server_name) .Values.identity_server.server_url }}
           - name: MANAGEMENTPORTAL_IDENTITY_SERVER_LOGIN_URL
-            value: {{ .Values.identity_server.login_url }}
+            value: {{ default (printf "https://%s/kratos-ui" .Values.server_name) .Values.identity_server.login_url }}
           - name: MANAGEMENTPORTAL_IDENTITY_SERVER_SERVER_ADMIN_URL
             value: {{ .Values.identity_server.server_admin_url }}
           - name: MANAGEMENTPORTAL_COMMON_ADMIN_PASSWORD

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -268,12 +268,13 @@ catalogue_server: catalog-server
 identity_server:
   # -- The admin email to link to the admin service account. This account should only be used to set up admin-users
   admin_email: admin@example.com
-  # -- The publicly accessible server URL for the IDP
-  server_url: https://my.example-domain.net/kratos
-  # -- The admin server URL for the IDP. Only needs to be accessible from inside the cluster where the managementportal resides
+  # -- The publicly accessible server URL for the IDP; needed when deviating from https://server_name/kratos
+  server_url:
+  # -- The admin server URL for the IDP used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides
   server_admin_url: http://kratos-admin
-  # -- The login URL for the IDP. Needs to be publicly accessible
-  login_url: https://my.example-domain.net/kratos-ui
+  # -- The login URL for the IDP; needed when deviating from https://server_name/kratos-ui
+  # -- Needs to be publicly accessible
+  login_url:
 
 managementportal:
   # -- set to true, if automatic source-type import from catalogue server should be enabled


### PR DESCRIPTION
# Problem
URLs for kratos had to be set in production.yaml for Ory integration to work.

# Solution
This PR will derive default values for Ory URLs. The current values can be used to override the defaults.