### PR TITLE
Removed ES from graylog

### DIFF
--- a/external/graylog/Chart.lock
+++ b/external/graylog/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mongodb
+  repository: https://radar-base.github.io/radar-helm-charts
+  version: 15.6.12
+digest: sha256:dc573bec321f7275ec570ccdef77b6b75a79ebe332853a0bc905a64141287c13
+generated: "2024-07-24T14:30:28.213590551Z"

--- a/external/graylog/Chart.yaml
+++ b/external/graylog/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 appVersion: 4.3.8
 dependencies:
-- name: elasticsearch
-  repository: https://radar-base.github.io/radar-helm-charts
-  tags:
-  - install-elasticsearch
-  version: 7.16.2
+  #- name: elasticsearch
+  #repository: https://radar-base.github.io/radar-helm-charts
+  # tags:
+  #- install-elasticsearch
+  #version: 7.16.2
 - name: mongodb
   repository: https://radar-base.github.io/radar-helm-charts
   tags:


### PR DESCRIPTION
To fix the build on main branch I think we first need to remove the ES from graylog and then added it again. This PR removes it and when the build works will make another PR to return it.