### PR TITLE
Downgrade radar appserver

### DIFF
--- a/charts/radar-appserver/Chart.yaml
+++ b/charts/radar-appserver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "2.4.3"
+appVersion: "2.4.2"
 description: A Helm chart for the backend application of RADAR-base Appserver
 name: radar-appserver
-version: 0.5.0
+version: 0.5.1
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-appserver

--- a/charts/radar-appserver/README.md
+++ b/charts/radar-appserver/README.md
@@ -3,7 +3,7 @@
 # radar-appserver
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-appserver)](https://artifacthub.io/packages/helm/radar-base/radar-appserver)
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.2](https://img.shields.io/badge/AppVersion-2.4.2-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Appserver
 


### PR DESCRIPTION
In #240 the appserver image have changed to 2.4.3 instead of 2.4.2. This PR will downgrade the appversion to the correct version.