### PR TITLE
[radar-gateway] Tune memory configuration

### DIFF
--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.7.2"
 description: A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 name: radar-gateway
-version: 1.2.0
+version: 1.2.1
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-gateway

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -3,7 +3,7 @@
 # radar-gateway
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-gateway)](https://artifacthub.io/packages/helm/radar-base/radar-gateway)
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 
@@ -49,7 +49,7 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | ingress.ingressClassName | string | `"nginx"` | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+) |
 | ingress.hosts | list | `["localhost"]` | Hosts to accept requests from |
 | ingress.tls.secretName | string | `"radar-base-tls-radar-gateway"` | Name of the secret that contains TLS certificates |
-| resources.requests | object | `{"cpu":"100m","memory":"128Mi"}` | CPU/Memory resource requests |
+| resources.requests | object | `{"cpu":"100m","memory":"400Mi"}` | CPU/Memory resource requests |
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | tolerations | list | `[]` | Toleration labels for pod assignment |
 | affinity | object | `{}` | Affinity labels for pod assignment |
@@ -72,8 +72,7 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | serviceMonitor.enabled | bool | `true` | Enable metrics to be collected via Prometheus-operator |
 | hpa.enabled | bool | `true` | Enable HPA |
 | hpa.maxReplicas | string | `"5"` | Maximum number of replicas |
-| hpa.targetCPU | string | `"50"` | Target CPU utilization percentage |
-| hpa.targetMemory | int | `85` | Target Memory utilization percentage |
+| hpa.targetCPU | string | `"80"` | Target CPU utilization percentage |
 | managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of the management portal application |
 | schemaRegistry | string | `"http://cp-schema-registry:8081"` | Schema Registry URL |
 | max_requests | int | `1000` | Not used. To be confirmed |

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -85,7 +85,7 @@ resources:
   # -- CPU/Memory resource requests
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 400Mi
 
 # -- Node labels for pod assignment
 nodeSelector: {}
@@ -192,9 +192,7 @@ hpa:
   # -- Maximum number of replicas
   maxReplicas: "5"
   # -- Target CPU utilization percentage
-  targetCPU: "50"
-  # -- Target Memory utilization percentage
-  targetMemory: 85
+  targetCPU: "80"
 
 # -- URL of the management portal application
 managementportal_url: http://management-portal:8080/managementportal


### PR DESCRIPTION
Radar gateway uses around 400MB of memory on idle mode, the requests now reflect that. HPA based on memory isn't very useful at the moment and it has been disabled.