### PR TITLE
Remove trailing slashes in rest-sources-backend URLs

### DIFF
--- a/charts/radar-rest-sources-authorizer/Chart.yaml
+++ b/charts/radar-rest-sources-authorizer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.3"
 description: A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 name: radar-rest-sources-authorizer
-version: 2.0.1
+version: 2.0.2
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-authorizer

--- a/charts/radar-rest-sources-authorizer/README.md
+++ b/charts/radar-rest-sources-authorizer/README.md
@@ -3,7 +3,7 @@
 # radar-rest-sources-authorizer
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-rest-sources-authorizer)](https://artifacthub.io/packages/helm/radar-base/radar-rest-sources-authorizer)
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.3](https://img.shields.io/badge/AppVersion-4.4.3-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.3](https://img.shields.io/badge/AppVersion-4.4.3-informational?style=flat-square)
 
 A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 

--- a/charts/radar-rest-sources-authorizer/templates/deployment.yaml
+++ b/charts/radar-rest-sources-authorizer/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - name: BASE_HREF
             value: /rest-sources/authorizer/
           - name: BACKEND_BASE_URL
-            value: {{ printf "%s://%s/rest-sources/backend/" $https .Values.serverName }}
+            value: {{ printf "%s://%s/rest-sources/backend" $https .Values.serverName }}
           - name: VALIDATE
             value: "true"
           - name: AUTH_GRANT_TYPE

--- a/charts/radar-rest-sources-backend/Chart.yaml
+++ b/charts/radar-rest-sources-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.3"
 description: A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 name: radar-rest-sources-backend
-version: 1.1.5
+version: 1.1.6
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-backend

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -3,7 +3,7 @@
 # radar-rest-sources-backend
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-rest-sources-backend)](https://artifacthub.io/packages/helm/radar-base/radar-rest-sources-backend)
 
-![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.3](https://img.shields.io/badge/AppVersion-4.4.3-informational?style=flat-square)
+![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.3](https://img.shields.io/badge/AppVersion-4.4.3-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 

--- a/charts/radar-rest-sources-backend/templates/configmap.yaml
+++ b/charts/radar-rest-sources-backend/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
     service:
       # Interval time in minutes for syncing projects and subjects.
       baseUri: http://0.0.0.0:8080/rest-sources/backend/
-      advertisedBaseUri: {{ printf "%s://%s/rest-sources/backend/" $https .Values.serverName }}
+      advertisedBaseUri: {{ printf "%s://%s/rest-sources/backend" $https .Values.serverName }}
       enableCors: true
       syncParticipantsIntervalMin: 2
       {{- if .Values.authorizer -}}


### PR DESCRIPTION
These slashes caused errors in the rest source authorizer frontend.