### PR TITLE
Add OAuth client to management portal for CI e2e testing

### DIFF
--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.1.5"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 1.2.5
+version: 1.3.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -3,7 +3,7 @@
 # management-portal
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
-![Version: 1.2.5](https://img.shields.io/badge/Version-1.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.5](https://img.shields.io/badge/AppVersion-2.1.5-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.5](https://img.shields.io/badge/AppVersion-2.1.5-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 

--- a/charts/management-portal/templates/secrets-config.yaml
+++ b/charts/management-portal/templates/secrets-config.yaml
@@ -26,7 +26,7 @@ client_id;resource_ids;client_secret;scope;authorized_grant_types;redirect_uri;a
 {{- end -}}
 {{- end -}}
 {{- end -}}
-{{- end}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -595,3 +595,55 @@ oauth_clients:
     authorized_grant_types:
       - client_credentials
     access_token_validity: 900
+
+  # This client is used for the CI to authenticate with the Management Portal
+  # Tokens obtained with it can be used for every activity in the platform.
+  ci_test_client:
+    # WARNING: never enable in production!
+    enable: false
+    resource_ids:
+      - res_ManagementPortal
+      - res_appconfig
+      - res_gateway
+      - res_upload
+      - res_restAuthorizer
+      - res_DataDashboardAPI
+      - res_appserver
+      - res_fitbit
+      - res_push
+      - res_integration
+      - res_redcap
+    # This secret is never randomized because it is used by the CI.
+    client_secret: secret
+    scope:
+      - PROJECT.CREATE
+      - PROJECT.READ
+      - PROJECT.UPDATE
+      - USER.CREATE
+      - USER.READ
+      - USER.UPDATE
+      - SUBJECT.CREATE
+      - SUBJECT.READ
+      - SUBJECT.UPDATE
+      - ROLE.CREATE
+      - ROLE.READ
+      - ROLE.UPDATE
+      - SOURCE.CREATE
+      - SOURCE.READ
+      - SOURCE.UPDATE
+      - SOURCEDATA.CREATE
+      - SOURCEDATA.READ
+      - SOURCEDATA.UPDATE
+      - SOURCETYPE.CREATE
+      - SOURCETYPE.READ
+      - SOURCETYPE.UPDATE
+      - MEASUREMENT.CREATE
+      - MEASUREMENT.READ
+      - MEASUREMENT.UPDATE
+    authorized_grant_types:
+      - refresh_token
+      - authorization_code
+      - client_credentials
+    access_token_validity: 86400000
+    refresh_token_validity: 86400000
+    additional_information: '{"dynamic_registration": true}'


### PR DESCRIPTION
# Problem
CI e2e testing with curl commands is difficult because of the different tokens that are needed to simulate the different applications.

# Solution
This PR will implement a _super token_ client. The token distributed by this client have the ability to access any other _resource_ and has any _scope_ (ability to do or have something) in RADAR-base.

The token can be requested from Management Potal using the client id _ci_test_client_ and client secret _secret_.