### PR TITLE
Reinstate authUrl value for rest-sources-authorizer

### DIFF
--- a/charts/radar-rest-sources-authorizer/Chart.yaml
+++ b/charts/radar-rest-sources-authorizer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.4"
 description: A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 name: radar-rest-sources-authorizer
-version: 2.0.4
+version: 2.0.5
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-authorizer

--- a/charts/radar-rest-sources-authorizer/README.md
+++ b/charts/radar-rest-sources-authorizer/README.md
@@ -3,7 +3,7 @@
 # radar-rest-sources-authorizer
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-rest-sources-authorizer)](https://artifacthub.io/packages/helm/radar-base/radar-rest-sources-authorizer)
 
-![Version: 2.0.4](https://img.shields.io/badge/Version-2.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.4](https://img.shields.io/badge/AppVersion-4.4.4-informational?style=flat-square)
+![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.4](https://img.shields.io/badge/AppVersion-4.4.4-informational?style=flat-square)
 
 A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 
@@ -72,3 +72,4 @@ A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer
 | networkpolicy | object | check `values.yaml` | Network policy defines who can access this application and who this applications has access to |
 | clientId | string | `"radar_rest_sources_authorizer"` | OAuth2 client id of the application registered in Management Portal. It is assumed that this is a public client with empty client secret. |
 | serverName | string | `"localhost"` | Domain name of the server |
+| authUrl | string | `nil` | Authorization URL of the IDP (overrides the default value derived from the serverName) |

--- a/charts/radar-rest-sources-authorizer/templates/deployment.yaml
+++ b/charts/radar-rest-sources-authorizer/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
           - name: AUTH_CALLBACK_URL
             value: {{ printf "%s://%s/rest-sources/authorizer/login" $https .Values.serverName }}
           - name: AUTH_URI
-            value: {{ printf "%s://%s/managementportal/oauth" $https .Values.serverName }}
+            value: {{ .Values.authUrl | default (printf "%s://%s/managementportal/oauth" $https .Values.serverName) }}
           {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/radar-rest-sources-authorizer/values.yaml
+++ b/charts/radar-rest-sources-authorizer/values.yaml
@@ -158,3 +158,5 @@ networkpolicy:
 clientId: radar_rest_sources_authorizer
 # -- Domain name of the server
 serverName: localhost
+# -- Authorization URL of the IDP (overrides the default value derived from the serverName)
+authUrl:


### PR DESCRIPTION
# Problem
CONNECT uses the intermediate implementation of Ory for 2FA. Bastiaan implemented this on a different MP URL. We previously removed the value _authUrl_ that allowed to set this custom URL. 

# Solution
This PR reinstes the _authUrl_ parameter.

# Note
It can be removed when the final implementation of Ory Kratos/Hydra has been released.