### PR TITLE
Separate advertised protocol (http, https) from disabling TLS

### DIFF
--- a/charts/app-config-frontend/Chart.yaml
+++ b/charts/app-config-frontend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.3
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/app-config-frontend/README.md
+++ b/charts/app-config-frontend/README.md
@@ -3,7 +3,7 @@
 # app-config-frontend
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/app-config-frontend)](https://artifacthub.io/packages/helm/radar-base/app-config-frontend)
 
-![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.2](https://img.shields.io/badge/AppVersion-0.5.2-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.2](https://img.shields.io/badge/AppVersion-0.5.2-informational?style=flat-square)
 
 A Helm chart for the frontend application of RADAR-base application config (app-config).
 
@@ -43,6 +43,8 @@ A Helm chart for the frontend application of RADAR-base application config (app-
 | securityContext | object | `{}` | Configure Appconfig containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | Appconfig frontend port |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
+| advertised_protocol | string | `"https"` | The protocol in advertised URIs (https, http) |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/appconfig"` | Path within the url structure |

--- a/charts/app-config-frontend/templates/deployment.yaml
+++ b/charts/app-config-frontend/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{ $https := ternary "http" "https" (or .Values.disable_tls (not .Values.ingress.tls)) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,9 +52,9 @@ spec:
             - name: APP_CONFIG_URL
               value: /appconfig/api
             - name: AUTH_URL
-              value: {{ printf "%s://%s/managementportal/oauth" $https .Values.serverName }}
+              value: {{ printf "%s://%s/managementportal/oauth" .Values.advertised_protocol .Values.serverName }}
             - name: AUTH_CALLBACK_URL
-              value: {{ printf "%s://%s/appconfig/login" $https .Values.serverName }}
+              value: {{ printf "%s://%s/appconfig/login" .Values.advertised_protocol .Values.serverName }}
           {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/app-config-frontend/values.yaml
+++ b/charts/app-config-frontend/values.yaml
@@ -44,6 +44,11 @@ service:
   # -- Appconfig frontend port
   port: 8080
 
+# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+disable_tls: false
+# - The protocol in advertised (return) URIs (https, http)
+advertised_protocol: https
+
 ingress:
   # -- Enable ingress controller resource
   enabled: true

--- a/charts/app-config-frontend/values.yaml
+++ b/charts/app-config-frontend/values.yaml
@@ -44,9 +44,9 @@ service:
   # -- Appconfig frontend port
   port: 8080
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
-# - The protocol in advertised (return) URIs (https, http)
+# -- The protocol in advertised URIs (https, http)
 advertised_protocol: https
 
 ingress:

--- a/charts/app-config/Chart.yaml
+++ b/charts/app-config/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.5.2"
 description: A Helm chart for RADAR-base application config (app-config) backend service which is used as mobile app configuration engine with per-project and per-user configuration.
 name: app-config
-version: 1.3.2
+version: 1.3.3
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/app-config

--- a/charts/app-config/README.md
+++ b/charts/app-config/README.md
@@ -3,7 +3,7 @@
 # app-config
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/app-config)](https://artifacthub.io/packages/helm/radar-base/app-config)
 
-![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.2](https://img.shields.io/badge/AppVersion-0.5.2-informational?style=flat-square)
+![Version: 1.3.3](https://img.shields.io/badge/Version-1.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.2](https://img.shields.io/badge/AppVersion-0.5.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base application config (app-config) backend service which is used as mobile app configuration engine with per-project and per-user configuration.
 
@@ -45,7 +45,7 @@ A Helm chart for RADAR-base application config (app-config) backend service whic
 | securityContext | object | `{}` | Configure Appconfig containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8090` | Appconfig port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/appconfig/api"` | Path within the url structure |

--- a/charts/app-config/values.yaml
+++ b/charts/app-config/values.yaml
@@ -51,7 +51,7 @@ service:
   # -- Appconfig port
   port: 8090
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
 
 ingress:

--- a/charts/cc-schema-registry-proxy/Chart.yaml
+++ b/charts/cc-schema-registry-proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Confluent Cloud schema registry proxy. This proxy service is used when RADAR-base platform is used with Confluent Cloud based schema registry. It forwards requests to schema registry with an additonal basic authentication header with Confluent Cloud schema registry credentials. This service will be enabled if `cc.enabled = true`.
 name: cc-schema-registry-proxy
-version: 0.3.2
+version: 0.3.3
 type: application
 home: "https://radar-base.org"
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"

--- a/charts/cc-schema-registry-proxy/README.md
+++ b/charts/cc-schema-registry-proxy/README.md
@@ -3,7 +3,7 @@
 # cc-schema-registry-proxy
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cc-schema-registry-proxy)](https://artifacthub.io/packages/helm/radar-base/cc-schema-registry-proxy)
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0](https://img.shields.io/badge/AppVersion-1.0-informational?style=flat-square)
 
 A Helm chart for Confluent Cloud schema registry proxy. This proxy service is used when RADAR-base platform is used with Confluent Cloud based schema registry. It forwards requests to schema registry with an additonal basic authentication header with Confluent Cloud schema registry credentials. This service will be enabled if `cc.enabled = true`.
 
@@ -34,7 +34,7 @@ A Helm chart for Confluent Cloud schema registry proxy. This proxy service is us
 | service.type | string | `"ExternalName"` | Kubernetes Service type, |
 | service.externalName | string | `"schema-registry-domain"` | Domain name used for pointing to actual schema registry instance |
 | service.port | int | `443` | Port number to connect to Confluent platform |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/schema/?(.*)"` | Path within the url structure |

--- a/charts/cc-schema-registry-proxy/values.yaml
+++ b/charts/cc-schema-registry-proxy/values.yaml
@@ -9,7 +9,7 @@ service:
   # -- Port number to connect to Confluent platform
   port: 443
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
 
 ingress:

--- a/charts/data-dashboard-backend/Chart.yaml
+++ b/charts/data-dashboard-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.2.2"
 name: data-dashboard-backend
 description: API for data in the data dashboard
-version: 0.3.4
+version: 0.3.5
 sources: ["https://github.com/thehyve/radar-data-dashboard-backend"]
 deprecated: false
 type: application

--- a/charts/data-dashboard-backend/README.md
+++ b/charts/data-dashboard-backend/README.md
@@ -2,7 +2,7 @@
 
 # data-dashboard-backend
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
 
 API for data in the data dashboard
 
@@ -40,7 +40,7 @@ API for data in the data dashboard
 | securityContext | object | `{}` | Configure container's Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `9000` | data-dashboard-backend port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.ingressClassName | string | `"nginx"` | Ingress class name |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |

--- a/charts/data-dashboard-backend/values.yaml
+++ b/charts/data-dashboard-backend/values.yaml
@@ -40,7 +40,7 @@ service:
   # -- data-dashboard-backend port
   port: 9000
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
 
 ingress:

--- a/charts/kafka-manager/Chart.yaml
+++ b/charts/kafka-manager/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kafka-manager
-version: 2.3.0
+version: 2.3.1
 appVersion: 1.3.3.18
 kubeVersion: "^1.8.0-0"
 description: A tool for managing Apache Kafka.

--- a/charts/kafka-manager/README.md
+++ b/charts/kafka-manager/README.md
@@ -66,7 +66,7 @@ The following table lists the configurable parameters of the Kafka Manager chart
 | image.tag | string | `nil` | Overrides the image tag whose default is the chart appVersion. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | imagePullSecrets | list | `[]` | Docker registry secret names as an array |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/kafkamanager/"` | Path within the url structure |

--- a/charts/kafka-manager/values.yaml
+++ b/charts/kafka-manager/values.yaml
@@ -147,7 +147,7 @@ image:
 # -- Docker registry secret names as an array
 imagePullSecrets: []
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
 
 ingress:

--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.1.5"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 1.2.6
+version: 1.3.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -3,7 +3,7 @@
 # management-portal
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
-![Version: 1.2.6](https://img.shields.io/badge/Version-1.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.5](https://img.shields.io/badge/AppVersion-2.1.5-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.5](https://img.shields.io/badge/AppVersion-2.1.5-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 
@@ -43,6 +43,7 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | Management Portal port |
 | disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| advertised_protocol | string | `"https"` |  |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/managementportal"` | Path within the url structure |

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -42,8 +42,8 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 | securityContext | object | `{}` | Configure management-portal containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | Management Portal port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
-| advertised_protocol | string | `"https"` |  |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
+| advertised_protocol | string | `"https"` | The protocol in advertised URIs (https, http) |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/managementportal"` | Path within the url structure |

--- a/charts/management-portal/templates/deployment.yaml
+++ b/charts/management-portal/templates/deployment.yaml
@@ -1,6 +1,5 @@
-{{ $https := ternary "http" "https" (or .Values.disable_tls (not .Values.ingress.tls)) }}
-{{ $idpLoginUrl  := .Values.identity_server.login_url | default (printf "%s://%s/kratos-ui" $https .Values.server_name) }}
-{{ $idpServerUrl := .Values.identity_server.server_url | default (printf "%s://%s/kratos"   $https .Values.server_name) }}
+{{ $idpLoginUrl  := .Values.identity_server.login_url | default (printf "%s://%s/kratos-ui" .Values.advertised_protocol .Values.server_name) }}
+{{ $idpServerUrl := .Values.identity_server.server_url | default (printf "%s://%s/kratos"   .Values.advertised_protocol .Values.server_name) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -73,9 +72,9 @@ spec:
           - name: MANAGEMENTPORTAL_MAIL_FROM
             value: {{ .Values.smtp.from }}
           - name: MANAGEMENTPORTAL_COMMON_BASEURL
-            value: {{ printf "%s://%s" $https .Values.server_name }}
+            value: {{ printf "%s://%s" .Values.advertised_protocol .Values.server_name }}
           - name: MANAGEMENTPORTAL_COMMON_MANAGEMENT_PORTAL_BASE_URL
-            value: {{ printf "%s://%s/managementportal" $https .Values.server_name }}
+            value: {{ printf "%s://%s/managementportal" .Values.advertised_protocol .Values.server_name }}
           - name: MANAGEMENTPORTAL_FRONTEND_CLIENT_SECRET
             valueFrom:
               secretKeyRef:

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -42,6 +42,8 @@ service:
 
 # -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
 disable_tls: false
+# - The protocol in advertised (return) URIs (https, http)
+advertised_protocol: https
 
 ingress:
   # -- Enable ingress controller resource

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -40,9 +40,9 @@ service:
   # -- Management Portal port
   port: 8080
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
-# - The protocol in advertised (return) URIs (https, http)
+# -- The protocol in advertised URIs (https, http)
 advertised_protocol: https
 
 ingress:

--- a/charts/radar-appserver/Chart.yaml
+++ b/charts/radar-appserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.4.3"
 description: A Helm chart for the backend application of RADAR-base Appserver
 name: radar-appserver
-version: 0.6.0
+version: 0.7.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-appserver

--- a/charts/radar-appserver/README.md
+++ b/charts/radar-appserver/README.md
@@ -3,7 +3,7 @@
 # radar-appserver
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-appserver)](https://artifacthub.io/packages/helm/radar-base/radar-appserver)
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Appserver
 
@@ -42,6 +42,7 @@ A Helm chart for the backend application of RADAR-base Appserver
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | radar-appserver port |
 | disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| advertised_protocol | string | `"https"` |  |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and session configuration |
 | ingress.path | string | `"/appserver/?(.*)"` | Path within the url structure |

--- a/charts/radar-appserver/README.md
+++ b/charts/radar-appserver/README.md
@@ -41,8 +41,8 @@ A Helm chart for the backend application of RADAR-base Appserver
 | securityContext | object | `{}` | Configure radar-appserver containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | radar-appserver port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
-| advertised_protocol | string | `"https"` |  |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
+| advertised_protocol | string | `"https"` | The protocol in advertised URIs (https, http) |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and session configuration |
 | ingress.path | string | `"/appserver/?(.*)"` | Path within the url structure |

--- a/charts/radar-appserver/templates/configmap.yaml
+++ b/charts/radar-appserver/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{ $https := ternary "http" "https" (or .Values.disable_tls (not .Values.ingress.tls)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,7 +16,7 @@ data:
 
     # Set of supported public key endpoints for authentication
     publicKeyEndpoints:
-        - {{ printf "%s://%s/managementportal/oauth/token_key" $https .Values.serverName | quote }}
+        - {{ printf "%s://%s/managementportal/oauth/token_key" .Values.advertised_protocol .Values.serverName | quote }}
         {{- range .Values.public_key_endpoints }}
         - {{ . | quote }}
         {{ end -}}

--- a/charts/radar-appserver/values.yaml
+++ b/charts/radar-appserver/values.yaml
@@ -43,6 +43,8 @@ service:
 
 # -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
 disable_tls: false
+# - The protocol in advertised (return) URIs (https, http)
+advertised_protocol: https
 
 ingress:
   # -- Enable ingress controller resource

--- a/charts/radar-appserver/values.yaml
+++ b/charts/radar-appserver/values.yaml
@@ -41,9 +41,9 @@ service:
   # -- radar-appserver port
   port: 8080
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
-# - The protocol in advertised (return) URIs (https, http)
+# -- The protocol in advertised URIs (https, http)
 advertised_protocol: https
 
 ingress:

--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.7.2"
 description: A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 name: radar-gateway
-version: 1.2.2
+version: 1.2.3
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-gateway

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -3,7 +3,7 @@
 # radar-gateway
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-gateway)](https://artifacthub.io/packages/helm/radar-base/radar-gateway)
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 
@@ -41,7 +41,7 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | securityContext | object | `{}` | Configure radar-gateway containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | radar-gateway port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and deny access to sensitive URLs |
 | ingress.path | string | `"/kafka/?(.*)"` | Path within the url structure |

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -41,7 +41,7 @@ service:
   # -- radar-gateway port
   port: 8080
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
 
 ingress:

--- a/charts/radar-home/Chart.yaml
+++ b/charts/radar-home/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.1.4"
 description: RADAR-base home page.
 name: radar-home
-version: 0.3.3
+version: 0.3.4
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-home

--- a/charts/radar-home/README.md
+++ b/charts/radar-home/README.md
@@ -3,7 +3,7 @@
 # radar-home
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-home)](https://artifacthub.io/packages/helm/radar-base/radar-home)
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.4](https://img.shields.io/badge/AppVersion-0.1.4-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.4](https://img.shields.io/badge/AppVersion-0.1.4-informational?style=flat-square)
 
 RADAR-base home page.
 
@@ -40,7 +40,7 @@ RADAR-base home page.
 | namespace | string | `"default"` | Kubernetes namespace that Appconfig is going to be deployed on |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | Port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/"` | Path within the url structure |

--- a/charts/radar-home/values.yaml
+++ b/charts/radar-home/values.yaml
@@ -31,7 +31,7 @@ service:
   # -- Port
   port: 8080
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
 
 ingress:

--- a/charts/radar-integration/Chart.yaml
+++ b/charts/radar-integration/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.0.5"
 description: A Helm chart for RADAR-Base REDCap survey integration application.
 name: radar-integration
-version: 0.7.1
+version: 0.7.2
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-integration

--- a/charts/radar-integration/README.md
+++ b/charts/radar-integration/README.md
@@ -3,7 +3,7 @@
 # radar-integration
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-integration)](https://artifacthub.io/packages/helm/radar-base/radar-integration)
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.5](https://img.shields.io/badge/AppVersion-1.0.5-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.5](https://img.shields.io/badge/AppVersion-1.0.5-informational?style=flat-square)
 
 A Helm chart for RADAR-Base REDCap survey integration application.
 
@@ -41,7 +41,7 @@ A Helm chart for RADAR-Base REDCap survey integration application.
 | securityContext | object | `{}` | Configure radar-integration containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | radar-integration port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and deny access to sensitive URLs |
 | ingress.path | string | `"/redcapint/?(.*)"` | Path within the url structure |

--- a/charts/radar-integration/values.yaml
+++ b/charts/radar-integration/values.yaml
@@ -41,7 +41,7 @@ service:
   # -- radar-integration port
   port: 8080
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
 
 ingress:

--- a/charts/radar-push-endpoint/Chart.yaml
+++ b/charts/radar-push-endpoint/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.3.2"
 description: A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming data from Push or Subscription based WEB APIs. It performs authentication, authorization and content validation. For more details of the configurations, see https://github.com/RADAR-base/RADAR-PushEndpoint.
 name: radar-push-endpoint
-version: 0.3.3
+version: 0.3.4
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-push-endpoint

--- a/charts/radar-push-endpoint/README.md
+++ b/charts/radar-push-endpoint/README.md
@@ -3,7 +3,7 @@
 # radar-push-endpoint
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-push-endpoint)](https://artifacthub.io/packages/helm/radar-base/radar-push-endpoint)
 
-![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.2](https://img.shields.io/badge/AppVersion-0.3.2-informational?style=flat-square)
+![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.2](https://img.shields.io/badge/AppVersion-0.3.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming data from Push or Subscription based WEB APIs. It performs authentication, authorization and content validation. For more details of the configurations, see https://github.com/RADAR-base/RADAR-PushEndpoint.
 
@@ -41,7 +41,7 @@ A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming d
 | securityContext | object | `{}` | Configure radar-push-endpoint containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8090` | radar-push-endpoint port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and deny access to sensitive URLs |
 | ingress.path | string | `"/push-endpoint"` | Path within the url structure |

--- a/charts/radar-push-endpoint/values.yaml
+++ b/charts/radar-push-endpoint/values.yaml
@@ -41,7 +41,7 @@ service:
   # -- radar-push-endpoint port
   port: 8090
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
 
 ingress:

--- a/charts/radar-rest-sources-authorizer/Chart.yaml
+++ b/charts/radar-rest-sources-authorizer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.4"
 description: A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 name: radar-rest-sources-authorizer
-version: 2.0.5
+version: 2.1.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-authorizer

--- a/charts/radar-rest-sources-authorizer/README.md
+++ b/charts/radar-rest-sources-authorizer/README.md
@@ -3,7 +3,7 @@
 # radar-rest-sources-authorizer
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-rest-sources-authorizer)](https://artifacthub.io/packages/helm/radar-base/radar-rest-sources-authorizer)
 
-![Version: 2.0.5](https://img.shields.io/badge/Version-2.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.4](https://img.shields.io/badge/AppVersion-4.4.4-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.4](https://img.shields.io/badge/AppVersion-4.4.4-informational?style=flat-square)
 
 A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer which is a portal to authorize the Fitbit connector to read data from Fitbit accounts.
 
@@ -42,7 +42,8 @@ A Helm chart for the front-end application of RADAR-base Rest Sources Authorizer
 | securityContext | object | `{}` | Configure radar-rest-sources-authorizer containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | radar-rest-sources-authorizer port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
+| advertised_protocol | string | `"https"` | The protocol in advertised URIs (https, http) |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/rest-sources/authorizer"` | Path within the url structure |

--- a/charts/radar-rest-sources-authorizer/templates/deployment.yaml
+++ b/charts/radar-rest-sources-authorizer/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{ $https := ternary "http" "https" (or .Values.disable_tls (not .Values.ingress.tls)) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -49,7 +48,7 @@ spec:
           - name: BASE_HREF
             value: /rest-sources/authorizer/
           - name: BACKEND_BASE_URL
-            value: {{ printf "%s://%s/rest-sources/backend" $https .Values.serverName }}
+            value: {{ printf "%s://%s/rest-sources/backend" .Values.advertised_protocol .Values.serverName }}
           - name: VALIDATE
             value: "true"
           - name: AUTH_GRANT_TYPE
@@ -59,9 +58,9 @@ spec:
           - name: AUTH_CLIENT_SECRET
             value: ""
           - name: AUTH_CALLBACK_URL
-            value: {{ printf "%s://%s/rest-sources/authorizer/login" $https .Values.serverName }}
+            value: {{ printf "%s://%s/rest-sources/authorizer/login" .Values.advertised_protocol .Values.serverName }}
           - name: AUTH_URI
-            value: {{ .Values.authUrl | default (printf "%s://%s/managementportal/oauth" $https .Values.serverName) }}
+            value: {{ .Values.authUrl | default (printf "%s://%s/managementportal/oauth" .Values.advertised_protocol .Values.serverName) }}
           {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 10 }}
           {{- end }}

--- a/charts/radar-rest-sources-authorizer/values.yaml
+++ b/charts/radar-rest-sources-authorizer/values.yaml
@@ -41,9 +41,9 @@ service:
   # -- radar-rest-sources-authorizer port
   port: 8080
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
-# - The protocol in advertised (return) URIs (https, http)
+# -- The protocol in advertised URIs (https, http)
 advertised_protocol: https
 
 ingress:

--- a/charts/radar-rest-sources-authorizer/values.yaml
+++ b/charts/radar-rest-sources-authorizer/values.yaml
@@ -43,6 +43,8 @@ service:
 
 # -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
 disable_tls: false
+# - The protocol in advertised (return) URIs (https, http)
+advertised_protocol: https
 
 ingress:
   # -- Enable ingress controller resource

--- a/charts/radar-rest-sources-backend/Chart.yaml
+++ b/charts/radar-rest-sources-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.4"
 description: A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 name: radar-rest-sources-backend
-version: 1.1.8
+version: 1.2.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-backend

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -43,7 +43,7 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | radar-rest-sources-backend port |
 | disable_tls | bool | `false` | Disable TLS (reconfigures Ingress) |
-| advertised_protocol | string | `"https"` |  |
+| advertised_protocol | string | `"https"` | The protocol in advertised URIs (https, http) |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and session configuration |
 | ingress.path | string | `"/rest-sources/backend"` | Path within the url structure |

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -3,7 +3,7 @@
 # radar-rest-sources-backend
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-rest-sources-backend)](https://artifacthub.io/packages/helm/radar-base/radar-rest-sources-backend)
 
-![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.4](https://img.shields.io/badge/AppVersion-4.4.4-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.4](https://img.shields.io/badge/AppVersion-4.4.4-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 
@@ -42,7 +42,8 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 | securityContext | object | `{}` | Configure radar-rest-sources-backend containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | radar-rest-sources-backend port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress) |
+| advertised_protocol | string | `"https"` |  |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and session configuration |
 | ingress.path | string | `"/rest-sources/backend"` | Path within the url structure |

--- a/charts/radar-rest-sources-backend/templates/configmap.yaml
+++ b/charts/radar-rest-sources-backend/templates/configmap.yaml
@@ -1,5 +1,4 @@
 {{- $restSourceClients := trim (include "radar-rest-sources-backend.enabledMapElementsAsList" .Values.restSourceClients) -}}
-{{ $https := ternary "http" "https" (or .Values.disable_tls (not .Values.ingress.tls)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,7 +10,7 @@ data:
     service:
       # Interval time in minutes for syncing projects and subjects.
       baseUri: http://0.0.0.0:8080/rest-sources/backend/
-      advertisedBaseUri: {{ printf "%s://%s/rest-sources/backend" $https .Values.serverName }}
+      advertisedBaseUri: {{ printf "%s://%s/rest-sources/backend" .Values.advertised_protocol .Values.serverName }}
       enableCors: true
       syncParticipantsIntervalMin: 2
       {{- if .Values.authorizer -}}

--- a/charts/radar-rest-sources-backend/values.yaml
+++ b/charts/radar-rest-sources-backend/values.yaml
@@ -43,7 +43,7 @@ service:
 
 # -- Disable TLS (reconfigures Ingress)
 disable_tls: false
-# - The protocol in advertised (return) URIs (https, http)
+# -- The protocol in advertised URIs (https, http)
 advertised_protocol: https
 
 ingress:

--- a/charts/radar-rest-sources-backend/values.yaml
+++ b/charts/radar-rest-sources-backend/values.yaml
@@ -41,8 +41,10 @@ service:
   # -- radar-rest-sources-backend port
   port: 8080
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Disable TLS (reconfigures Ingress)
 disable_tls: false
+# - The protocol in advertised (return) URIs (https, http)
+advertised_protocol: https
 
 ingress:
   # -- Enable ingress controller resource

--- a/charts/radar-upload-connect-backend/Chart.yaml
+++ b/charts/radar-upload-connect-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.5.14"
 description: A Helm chart for RADAR-base upload connector backend application. This application is an upload system that stores uploaded data and its metadata in PostgreSQL for later processing.
 name: radar-upload-connect-backend
-version: 0.4.3
+version: 0.5.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-upload-connect-backend

--- a/charts/radar-upload-connect-backend/README.md
+++ b/charts/radar-upload-connect-backend/README.md
@@ -3,7 +3,7 @@
 # radar-upload-connect-backend
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-upload-connect-backend)](https://artifacthub.io/packages/helm/radar-base/radar-upload-connect-backend)
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
 
 A Helm chart for RADAR-base upload connector backend application. This application is an upload system that stores uploaded data and its metadata in PostgreSQL for later processing.
 
@@ -43,6 +43,7 @@ A Helm chart for RADAR-base upload connector backend application. This applicati
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8085` | radar-upload-connect-backend port |
 | disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| advertised_protocol | string | `"https"` |  |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and proxy settings |
 | ingress.path | string | `"/upload/api/?(.*)"` | Path within the url structure |

--- a/charts/radar-upload-connect-backend/README.md
+++ b/charts/radar-upload-connect-backend/README.md
@@ -42,8 +42,8 @@ A Helm chart for RADAR-base upload connector backend application. This applicati
 | securityContext | object | `{}` | Configure radar-upload-connect-backend containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8085` | radar-upload-connect-backend port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
-| advertised_protocol | string | `"https"` |  |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
+| advertised_protocol | string | `"https"` | The protocol in advertised URIs (https, http) |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and proxy settings |
 | ingress.path | string | `"/upload/api/?(.*)"` | Path within the url structure |

--- a/charts/radar-upload-connect-backend/templates/configmap.yaml
+++ b/charts/radar-upload-connect-backend/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{ $https := ternary "http" "https" (or .Values.disable_tls (not .Values.ingress.tls)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,7 +7,7 @@ metadata:
 data:
   upload.yml: |
     baseUri: "http://0.0.0.0:8085/upload/api/"
-    advertisedBaseUri: {{ printf "%s://%s/upload/api" $https .Values.serverName }}
+    advertisedBaseUri: {{ printf "%s://%s/upload/api" .Values.advertised_protocol .Values.serverName }}
     enableCors: yes
     clientId: {{ .Values.client_id }}
     clientSecret: {{ .Values.client_secret }}

--- a/charts/radar-upload-connect-backend/values.yaml
+++ b/charts/radar-upload-connect-backend/values.yaml
@@ -43,6 +43,8 @@ service:
 
 # -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
 disable_tls: false
+# - The protocol in advertised (return) URIs (https, http)
+advertised_protocol: https
 
 ingress:
   # -- Enable ingress controller resource

--- a/charts/radar-upload-connect-backend/values.yaml
+++ b/charts/radar-upload-connect-backend/values.yaml
@@ -41,9 +41,9 @@ service:
   # -- radar-upload-connect-backend port
   port: 8085
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
-# - The protocol in advertised (return) URIs (https, http)
+# -- The protocol in advertised URIs (https, http)
 advertised_protocol: https
 
 ingress:

--- a/charts/radar-upload-connect-frontend/Chart.yaml
+++ b/charts/radar-upload-connect-frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.5.14"
 description: A Helm chart for RADAR-base upload connector frontend application that provides a UI for uploading files and sending them to the upload-backend.
 name: radar-upload-connect-frontend
-version: 0.4.3
+version: 0.5.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-upload-connect-frontend

--- a/charts/radar-upload-connect-frontend/README.md
+++ b/charts/radar-upload-connect-frontend/README.md
@@ -42,8 +42,8 @@ A Helm chart for RADAR-base upload connector frontend application that provides 
 | securityContext | object | `{}` | Configure radar-upload-connect-frontend containers' Security Context |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `80` | radar-upload-connect-frontend port |
-| disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
-| advertised_protocol | string | `"https"` |  |
+| disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
+| advertised_protocol | string | `"https"` | The protocol in advertised URIs (https, http) |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/upload/?(.*)"` | Path within the url structure |

--- a/charts/radar-upload-connect-frontend/README.md
+++ b/charts/radar-upload-connect-frontend/README.md
@@ -3,7 +3,7 @@
 # radar-upload-connect-frontend
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-upload-connect-frontend)](https://artifacthub.io/packages/helm/radar-base/radar-upload-connect-frontend)
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
 
 A Helm chart for RADAR-base upload connector frontend application that provides a UI for uploading files and sending them to the upload-backend.
 
@@ -43,6 +43,7 @@ A Helm chart for RADAR-base upload connector frontend application that provides 
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `80` | radar-upload-connect-frontend port |
 | disable_tls | bool | `false` | Disable TLS (reconfigures Ingress and sets URLs to use HTTP) |
+| advertised_protocol | string | `"https"` |  |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer |
 | ingress.path | string | `"/upload/?(.*)"` | Path within the url structure |

--- a/charts/radar-upload-connect-frontend/templates/deployment.yaml
+++ b/charts/radar-upload-connect-frontend/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{ $https := ternary "http" "https" (or .Values.disable_tls (not .Values.ingress.tls)) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -49,9 +48,9 @@ spec:
           - name: VUE_APP_BASE_URL
             value: "/upload"
           - name: VUE_APP_API_BASE_URL
-            value: {{ printf "%s://%s/upload/api" .Values.server_name}}
+            value: {{ printf "%s://%s/upload/api" .Values.advertised_protocol .Values.server_name }}
           - name: VUE_APP_AUTH_API
-            value: {{ printf "%s://%s/managementportal/oauth" .Values.server_name }}
+            value: {{ printf "%s://%s/managementportal/oauth" .Values.advertised_protocol .Values.server_name }}
           - name: VUE_APP_AUTH_CALLBACK
             value: "{{ .Values.server_name }}/upload/login"
           - name: VUE_APP_CLIENT_ID

--- a/charts/radar-upload-connect-frontend/values.yaml
+++ b/charts/radar-upload-connect-frontend/values.yaml
@@ -41,9 +41,9 @@ service:
   # -- radar-upload-connect-frontend port
   port: 80
 
-# -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
+# -- Reconfigure Ingress to not force TLS
 disable_tls: false
-# - The protocol in advertised (return) URIs (https, http)
+# -- The protocol in advertised URIs (https, http)
 advertised_protocol: https
 
 ingress:

--- a/charts/radar-upload-connect-frontend/values.yaml
+++ b/charts/radar-upload-connect-frontend/values.yaml
@@ -43,6 +43,8 @@ service:
 
 # -- Disable TLS (reconfigures Ingress and sets URLs to use HTTP)
 disable_tls: false
+# - The protocol in advertised (return) URIs (https, http)
+advertised_protocol: https
 
 ingress:
   # -- Enable ingress controller resource


### PR DESCRIPTION
# Problem
When instructing the ingress to not demand TLS, the advertised protocol (HTTP, HTTPS) would switch to HTTP. This was ok for local testing, but was not desired for when TLS termination is handled by upstream component; services behind TLS termination would advertise an incorrect URI.

# Solution
This PR separates the options for TLS termination from the advertised protocol.

