### PR TITLE
Set ingress proxy-body-size when upload enabled in appserver

### DIFF
--- a/charts/radar-appserver/Chart.yaml
+++ b/charts/radar-appserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.4.3"
 description: A Helm chart for the backend application of RADAR-base Appserver
 name: radar-appserver
-version: 0.7.0
+version: 0.7.1
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-appserver

--- a/charts/radar-appserver/README.md
+++ b/charts/radar-appserver/README.md
@@ -3,7 +3,7 @@
 # radar-appserver
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-appserver)](https://artifacthub.io/packages/helm/radar-base/radar-appserver)
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.3](https://img.shields.io/badge/AppVersion-2.4.3-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Appserver
 
@@ -95,7 +95,7 @@ A Helm chart for the backend application of RADAR-base Appserver
 | smtp.starttls | bool | `false` | set to true,if TTLS should be enabled |
 | smtp.auth | bool | `true` | set to true, if the account should be authenticated before sending emails |
 | upload.enabled | bool | `false` | if set to true, file upload endpoint will be enabled |
-| upload.max_file_size | string | `"20MB"` | Maximum file size for upload |
+| upload.max_file_size | string | `"20MB"` | Maximum file size for upload. Can be any number followed by MB or GB. |
 | upload.storage.type | string | `"s3"` | Type of storage to use for file upload (s3) |
 | upload.storage.url | string | `"http://minio-headless:9000"` | Internal url to storage |
 | upload.storage.bucket_name | string | `"radar-output-storage"` | Bucket name of the S3 storage |

--- a/charts/radar-appserver/templates/ingress.yaml
+++ b/charts/radar-appserver/templates/ingress.yaml
@@ -18,6 +18,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.upload.max_file_size | lower | trimAll "b" }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
 {{- if and .Values.ingress.tls (not .Values.disable_tls) }}

--- a/charts/radar-appserver/values.yaml
+++ b/charts/radar-appserver/values.yaml
@@ -240,8 +240,8 @@ smtp:
 upload:
   # -- if set to true, file upload endpoint will be enabled
   enabled: false
-  # -- Maximum file size for upload
-  max_file_size: "20MB"
+  # -- Maximum file size for upload. Can be any number followed by MB or GB.
+  max_file_size: 20MB
   # Settings for file storage
   storage:
     # -- Type of storage to use for file upload (s3)


### PR DESCRIPTION
Config option _nginx.ingress.kubernetes.io/proxy-body-size_ was missing from the ingess to enable upload of large files.