### PR TITLE
Create default public key endpoint for radar-gateway

### DIFF
--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.7.2"
 description: A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 name: radar-gateway
-version: 1.2.5
+version: 1.2.6
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-gateway

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -3,7 +3,7 @@
 # radar-gateway
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-gateway)](https://artifacthub.io/packages/helm/radar-base/radar-gateway)
 
-![Version: 1.2.5](https://img.shields.io/badge/Version-1.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 1.2.6](https://img.shields.io/badge/Version-1.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 
@@ -42,6 +42,7 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8080` | radar-gateway port |
 | disable_tls | bool | `false` | Reconfigure Ingress to not force TLS |
+| advertised_protocol | string | `"https"` | The protocol in advertised URIs (https, http) |
 | ingress.enabled | bool | `true` | Enable ingress controller resource |
 | ingress.annotations | object | check values.yaml | Annotations that define default ingress class, certificate issuer and deny access to sensitive URLs |
 | ingress.path | string | `"/kafka/?(.*)"` | Path within the url structure |
@@ -88,4 +89,6 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | cc.apiSecret | string | `"ccApiSecret"` | Confluent Cloud cluster API secret |
 | cc.schemaRegistryApiKey | string | `"srApiKey"` | Confluent Cloud schema registry API key |
 | cc.schemaRegistryApiSecret | string | `"srApiSecret"` | Confluent Cloud schema registry API secret |
+| public_key_endpoints_enabled | bool | `false` | Enables config of public key endpoints for token verification This config option is implemented to fix a compatibility issue with radar-gateway. It can be removed when the publicKeyUrls config option is merged to master. |
 | public_key_endpoints | list | `[]` | List of public key endpoints for token verification |
+| serverName | string | `"localhost"` | Resolvable server name, needed to find the advertised URL and callback URL |

--- a/charts/radar-gateway/templates/configmap.yaml
+++ b/charts/radar-gateway/templates/configmap.yaml
@@ -56,7 +56,10 @@ data:
     auth:
       managementPortalUrl: {{ .Values.managementportal_url }}
       checkSourceId: {{ .Values.checkSourceId }}
+      {{- if or .Values.public_key_endpoints_enabled .Values.public_key_endpoints }}
       publicKeyUrls:
+        - {{ printf "%s://%s/managementportal/oauth/token_key" .Values.advertised_protocol .Values.serverName | quote }}
         {{- range .Values.public_key_endpoints }}
         - {{ . | quote }}
         {{ end -}}
+      {{- end}}

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -43,6 +43,8 @@ service:
 
 # -- Reconfigure Ingress to not force TLS
 disable_tls: false
+# -- The protocol in advertised URIs (https, http)
+advertised_protocol: https
 
 ingress:
   # -- Enable ingress controller resource
@@ -229,6 +231,12 @@ cc:
   # -- Confluent Cloud schema registry API secret
   schemaRegistryApiSecret: srApiSecret
 
+# -- Enables config of public key endpoints for token verification
+# This config option is implemented to fix a compatibility issue with radar-gateway.
+# It can be removed when the publicKeyUrls config option is merged to master.
+public_key_endpoints_enabled: false
 # -- List of public key endpoints for token verification
 public_key_endpoints: []
-  # - https://localhost/managementportal/oauth/token_key
+
+# -- Resolvable server name, needed to find the advertised URL and callback URL
+serverName: localhost


### PR DESCRIPTION
# Problem
Previous PR introduced public key endpoint for radar-gateway. This implementation did not include config for a sensible default value.

# Solution
This PR will provide a default value that respects the protocol (http, https) which is needed for local testing.