### PR TITLE
Do not include jmx pods when monitoring is disabled

### DIFF
--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.7.2"
 description: A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 name: radar-gateway
-version: 1.2.3
+version: 1.2.4
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-gateway

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -3,7 +3,7 @@
 # radar-gateway
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-gateway)](https://artifacthub.io/packages/helm/radar-base/radar-gateway)
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
+![Version: 1.2.4](https://img.shields.io/badge/Version-1.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.2](https://img.shields.io/badge/AppVersion-0.7.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 

--- a/charts/radar-gateway/templates/deployment.yaml
+++ b/charts/radar-gateway/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name | quote }}
       labels:
         app.kubernetes.io/name: {{ include "radar-gateway.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/radar-gateway/templates/deployment.yaml
+++ b/charts/radar-gateway/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
                     - {{ .Release.Name }}
               topologyKey: "kubernetes.io/hostname"
       containers:
+      {{- if .Values.serviceMonitor.enabled }}
         - image: sscaling/jmx-prometheus-exporter
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -59,6 +60,7 @@ spec:
           volumeMounts:
           - mountPath: /etc/radar-gateway/
             name: gateway-jmx-configmap
+      {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/radar-gateway/templates/jmx-configmap.yaml
+++ b/charts/radar-gateway/templates/jmx-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +11,4 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+{{- end }}

--- a/charts/radar-gateway/templates/service.yaml
+++ b/charts/radar-gateway/templates/service.yaml
@@ -11,10 +11,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.serviceMonitor.enabled }}
     - name: metrics
       port: 5556
       protocol: TCP
       targetPort: metrics
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "radar-gateway.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/radar-push-endpoint/Chart.yaml
+++ b/charts/radar-push-endpoint/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.3.2"
 description: A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming data from Push or Subscription based WEB APIs. It performs authentication, authorization and content validation. For more details of the configurations, see https://github.com/RADAR-base/RADAR-PushEndpoint.
 name: radar-push-endpoint
-version: 0.3.4
+version: 0.3.5
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-push-endpoint

--- a/charts/radar-push-endpoint/README.md
+++ b/charts/radar-push-endpoint/README.md
@@ -3,7 +3,7 @@
 # radar-push-endpoint
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-push-endpoint)](https://artifacthub.io/packages/helm/radar-base/radar-push-endpoint)
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.2](https://img.shields.io/badge/AppVersion-0.3.2-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.2](https://img.shields.io/badge/AppVersion-0.3.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming data from Push or Subscription based WEB APIs. It performs authentication, authorization and content validation. For more details of the configurations, see https://github.com/RADAR-base/RADAR-PushEndpoint.
 

--- a/charts/radar-push-endpoint/templates/deployment.yaml
+++ b/charts/radar-push-endpoint/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
                     - {{ .Release.Name }}
               topologyKey: "kubernetes.io/hostname"
       containers:
+      {{- if .Values.serviceMonitor.enabled }}
         - image: sscaling/jmx-prometheus-exporter
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
@@ -59,6 +60,7 @@ spec:
           volumeMounts:
           - mountPath: /etc/radar-push-endpoint/
             name: gateway-jmx-configmap
+      {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/radar-push-endpoint/templates/deployment.yaml
+++ b/charts/radar-push-endpoint/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name | quote }}
       labels:
         app.kubernetes.io/name: {{ include "radar-push-endpoint.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/radar-push-endpoint/templates/jmx-configmap.yaml
+++ b/charts/radar-push-endpoint/templates/jmx-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +11,4 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+{{- end }}

--- a/charts/radar-push-endpoint/templates/service.yaml
+++ b/charts/radar-push-endpoint/templates/service.yaml
@@ -11,10 +11,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.serviceMonitor.enabled }}
     - name: metrics
       port: 5556
       protocol: TCP
       targetPort: metrics
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "radar-push-endpoint.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
# Problem
Although the charts allow for disabling service monitoring, monitoring-related resources were created for radar-gateway and radar-push-endpoint. This would claim unneccessary resources on local test and development deploymen.

# Solution
This PR removes Kubernetes assets from radar-gateway and radar-push-endpoint when monitoring is disabled.