### PR TITLE
Allow configuration of Fitbit API url

### DIFF
--- a/charts/radar-fitbit-connector/Chart.yaml
+++ b/charts/radar-fitbit-connector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.5.4"
 description: A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 name: radar-fitbit-connector
-version: 0.3.5
+version: 0.4.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-fitbit-connector

--- a/charts/radar-fitbit-connector/README.md
+++ b/charts/radar-fitbit-connector/README.md
@@ -3,7 +3,7 @@
 # radar-fitbit-connector
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-fitbit-connector)](https://artifacthub.io/packages/helm/radar-base/radar-fitbit-connector)
 
-![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.4](https://img.shields.io/badge/AppVersion-0.5.4-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.4](https://img.shields.io/badge/AppVersion-0.5.4-informational?style=flat-square)
 
 A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 
@@ -76,6 +76,7 @@ A Helm chart for RADAR-base fitbit connector. This application collects data fro
 | kafka_wait.properties | string | `""` | Kafka connection properties file contents during wait. If empty, all environment variables starting with `CONNECT_` will be used. |
 | radar_rest_sources_backend_url | string | `"http://radar-rest-sources-backend:8080/rest-sources/backend/"` | Base URL of the rest-sources-authorizer-backend service |
 | connector_num_tasks | string | `"5"` | Number of connector tasks to be used in connector.properties |
+| fitbit_api_url | string | `"https://api.fitbit.com"` | Fitbit API URL. |
 | fitbit_api_client | string | `""` | Fitbit API client id. |
 | fitbit_api_secret | string | `""` | Fitbit API client secret. |
 | oauthClientId | string | `"radar_fitbit_connector"` | OAuth2 client id from Management Portal |

--- a/charts/radar-fitbit-connector/templates/configmap-properties.yaml
+++ b/charts/radar-fitbit-connector/templates/configmap-properties.yaml
@@ -9,7 +9,7 @@ data:
     name=radar-fitbit-source
     connector.class=org.radarbase.connect.rest.fitbit.FitbitSourceConnector
     tasks.max={{ .Values.connector_num_tasks }}
-    rest.source.base.url=https://api.fitbit.com
+    rest.source.base.url={{ .Values.fitbit_api_url }}
     rest.source.poll.interval.ms=5000
     rest.source.request.generator.class=org.radarbase.connect.rest.fitbit.request.FitbitRequestGenerator
     fitbit.api.client={{ .Values.fitbit_api_client }}

--- a/charts/radar-fitbit-connector/values.yaml
+++ b/charts/radar-fitbit-connector/values.yaml
@@ -203,6 +203,9 @@ kafka_wait:
 radar_rest_sources_backend_url: http://radar-rest-sources-backend:8080/rest-sources/backend/
 # -- Number of connector tasks to be used in connector.properties
 connector_num_tasks: "5"
+
+# -- Fitbit API URL.
+fitbit_api_url: https://api.fitbit.com
 # -- Fitbit API client id.
 fitbit_api_client: ""
 # -- Fitbit API client secret.


### PR DESCRIPTION
# Problem
During e2e testing of the Fitbit connector we cannot mock the Fitbit API since the URL is hardcoded.

# Solution
This PR will update the chart to make the Fitbit URL configurable.