### PR TITLE
Fixed radar upload backend network policy

### DIFF
--- a/charts/radar-upload-connect-backend/Chart.yaml
+++ b/charts/radar-upload-connect-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.5.14"
 description: A Helm chart for RADAR-base upload connector backend application. This application is an upload system that stores uploaded data and its metadata in PostgreSQL for later processing.
 name: radar-upload-connect-backend
-version: 0.5.1
+version: 0.5.2
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-upload-connect-backend

--- a/charts/radar-upload-connect-backend/README.md
+++ b/charts/radar-upload-connect-backend/README.md
@@ -3,7 +3,7 @@
 # radar-upload-connect-backend
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-upload-connect-backend)](https://artifacthub.io/packages/helm/radar-base/radar-upload-connect-backend)
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
 
 A Helm chart for RADAR-base upload connector backend application. This application is an upload system that stores uploaded data and its metadata in PostgreSQL for later processing.
 

--- a/charts/radar-upload-connect-backend/values.yaml
+++ b/charts/radar-upload-connect-backend/values.yaml
@@ -159,7 +159,7 @@ networkpolicy:
           kubernetes.io/metadata.name: '{{ .Release.Namespace }}'
       podSelector:
         matchLabels:
-          app.kubernetes.io/name: '{{ .Values.postgres.host | trunc 63 | trimSuffix "-" }}'
+          app.kubernetes.io/instance: '{{ .Values.postgres.host | trunc 63 | trimSuffix "-" }}'
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: '{{ .Release.Namespace }}'


### PR DESCRIPTION
Since we reuse PostgreSQL chart and change its name, the selector label also needs to change to match that.
```
  labels:
    app.kubernetes.io/component: primary
    app.kubernetes.io/instance: radar-upload-postgresql
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: postgresql
    apps.kubernetes.io/pod-index: "0"
    controller-revision-hash: radar-upload-postgresql-7c65bcc55c
    helm.sh/chart: postgresql-12.1.9
    statefulset.kubernetes.io/pod-name: radar-upload-postgresql-0
```