### PR TITLE
Fixed radar upload backend PostgreSQL configuration

### DIFF
--- a/charts/radar-upload-connect-backend/Chart.yaml
+++ b/charts/radar-upload-connect-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.5.14"
 description: A Helm chart for RADAR-base upload connector backend application. This application is an upload system that stores uploaded data and its metadata in PostgreSQL for later processing.
 name: radar-upload-connect-backend
-version: 0.5.2
+version: 0.5.3
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-upload-connect-backend

--- a/charts/radar-upload-connect-backend/README.md
+++ b/charts/radar-upload-connect-backend/README.md
@@ -3,7 +3,7 @@
 # radar-upload-connect-backend
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-upload-connect-backend)](https://artifacthub.io/packages/helm/radar-base/radar-upload-connect-backend)
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
+![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
 
 A Helm chart for RADAR-base upload connector backend application. This application is an upload system that stores uploaded data and its metadata in PostgreSQL for later processing.
 

--- a/charts/radar-upload-connect-backend/templates/configmap.yaml
+++ b/charts/radar-upload-connect-backend/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
     jdbcUser: {{ .Values.postgres.user }}
     jdbcPassword: {{ .Values.postgres.password }}
     additionalPersistenceConfig:
-      "hibernate.dialect": "org.hibernate.dialect.PostgreSQL95Dialect"
+      "hibernate.dialect": "org.hibernate.dialect.PostgreSQLDialect"
     sourceTypes:
       - name: "altoida"
         topics:


### PR DESCRIPTION
This PR resolves this error message:
```
[2024-11-14 16:00:54,320] INFO  - HikariPool-1 - Starting... (HikariDataSource.java:80)
[2024-11-14 16:00:54,401] INFO  - HikariPool-1 - Start completed. (HikariDataSource.java:82)
[2024-11-14 16:00:54,429] WARN  - HHH000342: Could not obtain connection to query metadata (JdbcEnvironmentInitiator.java:345)
org.hibernate.boot.registry.selector.spi.StrategySelectionException: Unable to resolve name [org.hibernate.dialect.PostgreSQL95Dialect] as strategy [org.hibernate.dialect.Dialect]
	at org.hibernate.boot.registry.selector.internal.StrategySelectorImpl.selectStrategyImplementor(StrategySelectorImpl.java:154) ~[hibernate-core-6.4.2.Final.jar:6.4.2.Final]
	at org.hibernate.boot.registry.selector.internal.StrategySelectorImpl.resolveStrategy(StrategySelectorImpl.java:236) ~[hibernate-core-6.4.2.Final.jar:6.4.2.Final]
	at org.hibernate.boot.registry.selector.internal.StrategySelectorImpl.resolveStrategy(StrategySelectorImpl.java:189) ~[hibernate-core-6.4.2.Final.jar:6.4.2.Final]
	at org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl.constructDialect(DialectFactoryImpl.java:123) ~[hibernate-core-6.4.2.Final.jar:6.4.2.Final]
	at org.hibernate.engine.jdbc.dialect.internal.DialectFactoryImpl.buildDialect(DialectFactoryImpl.java:88) ~[hibernate-core-6.4.2.Final.jar:6.4.2.Final]
	at org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator$1.execute(JdbcEnvironmentInitiator.java:328) ~[hibernate-core-6.4.2.Final.jar:6.4.2.Final]
	at org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator$1.execute(JdbcEnvironmentInitiator.java:277) ~[hibernate-core-6.4.2.Final.jar:6.4.2.Final]
	at org.hibernate.jdbc.WorkExecutor.executeReturningWork(WorkExecutor.java:58) ~[hibernate-core-6.4.2.Final.jar:6.4.2.Final]
```