### PR TITLE
[radar-fitbit-connector] Allow config of application intervals

### DIFF
--- a/charts/radar-fitbit-connector/Chart.yaml
+++ b/charts/radar-fitbit-connector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.5.4"
 description: A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 name: radar-fitbit-connector
-version: 0.4.0
+version: 0.5.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-fitbit-connector

--- a/charts/radar-fitbit-connector/README.md
+++ b/charts/radar-fitbit-connector/README.md
@@ -3,7 +3,7 @@
 # radar-fitbit-connector
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-fitbit-connector)](https://artifacthub.io/packages/helm/radar-base/radar-fitbit-connector)
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.4](https://img.shields.io/badge/AppVersion-0.5.4-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.4](https://img.shields.io/badge/AppVersion-0.5.4-informational?style=flat-square)
 
 A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 
@@ -44,6 +44,7 @@ A Helm chart for RADAR-base fitbit connector. This application collects data fro
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | service.port | int | `8083` | radar-fitbit-connector port |
 | resources.requests | object | `{"cpu":"100m","memory":"1Gi"}` | CPU/Memory resource requests |
+| heapOptions | string | `"-Xms256m -Xmx768m"` |  |
 | persistence.enabled | bool | `true` | Enable persistence using PVC |
 | persistence.accessMode | string | `"ReadWriteOnce"` | PVC Access Mode for radar-fitbit-connector volume |
 | persistence.size | string | `"5Gi"` | PVC Storage Request for radar-fitbit-connector volume |
@@ -83,3 +84,7 @@ A Helm chart for RADAR-base fitbit connector. This application collects data fro
 | oauthClientSecret | string | `"secret"` | OAuth2 client secret from Management Portal |
 | managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of Management Portal. This will be used to create URLs to access Management Portal |
 | includeIntradayData | bool | `true` | Set to true, if intraday access data should be collected by the connector. This will be set in connector.properties. |
+| rest_source_poll_interval_ms | int | `60000` | How often to poll the source URL. Only use to speed up processing times during e2e testing. |
+| fitbit_user_poll_interval | int | `5000` | Polling interval per Fitbit user per request route in seconds. Only use to speed up processing times during e2e testing. |
+| application_loop_interval_ms | int | `300000` | How often to perform the main application loop (only controls how often to poll for new user registrations). Only use to speed up processing times during e2e testing. |
+| user_cache_refresh_interval_ms | int | `3600000` | How often to invalidate the cache and poll for new user registrations. Only use to speed up processing times during e2e testing. |

--- a/charts/radar-fitbit-connector/templates/configmap-properties.yaml
+++ b/charts/radar-fitbit-connector/templates/configmap-properties.yaml
@@ -10,7 +10,7 @@ data:
     connector.class=org.radarbase.connect.rest.fitbit.FitbitSourceConnector
     tasks.max={{ .Values.connector_num_tasks }}
     rest.source.base.url={{ .Values.fitbit_api_url }}
-    rest.source.poll.interval.ms=5000
+    rest.source.poll.interval.ms={{ .Values.rest_source_poll_interval_ms | int }}
     rest.source.request.generator.class=org.radarbase.connect.rest.fitbit.request.FitbitRequestGenerator
     fitbit.api.client={{ .Values.fitbit_api_client }}
     fitbit.api.secret={{ .Values.fitbit_api_secret }}
@@ -20,6 +20,9 @@ data:
     fitbit.user.repository.client.id={{ .Values.oauthClientId }}
     fitbit.user.repository.client.secret={{ .Values.oauthClientSecret }}
     fitbit.user.repository.oauth2.token.url={{ .Values.managementportal_url }}/oauth/token
+    fitbit.user.poll.interval={{ .Values.fitbit_user_poll_interval | int }}
+    application.loop.interval.ms={{ .Values.application_loop_interval_ms | int }}
+    user.cache.refresh.interval.ms={{ .Values.user_cache_refresh_interval_ms | int}}
   {{- if and .Values.kafka_wait.enabled .Values.kafka_wait.properties }}
   kafka-wait.properties: |
     {{ .Values.kafka_wait.properties | indent 4 }}

--- a/charts/radar-fitbit-connector/templates/deployment.yaml
+++ b/charts/radar-fitbit-connector/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
           - name: CONNECTOR_PROPERTY_FILE_PREFIX
             value: "source-fitbit/source-fitbit"
           - name: KAFKA_HEAP_OPTS
-            value: "-Xms256m -Xmx768m"
+            value: {{ .Values.heapOptions }}
           - name: KAFKA_BROKERS
             value: "{{ .Values.kafka_num_brokers }}"
           - name: CONNECT_LOG4J_LOGGERS

--- a/charts/radar-fitbit-connector/values.yaml
+++ b/charts/radar-fitbit-connector/values.yaml
@@ -55,6 +55,8 @@ resources:
     cpu: 100m
     memory: 1Gi
 
+heapOptions: "-Xms256m -Xmx768m"
+
 persistence:
   # -- Enable persistence using PVC
   enabled: true
@@ -219,3 +221,17 @@ oauthClientSecret: secret
 managementportal_url: http://management-portal:8080/managementportal
 # -- Set to true, if intraday access data should be collected by the connector. This will be set in connector.properties.
 includeIntradayData: true
+
+
+# -- How often to poll the source URL.
+# Only use to speed up processing times during e2e testing.
+rest_source_poll_interval_ms: 60000
+# -- Polling interval per Fitbit user per request route in seconds.
+# Only use to speed up processing times during e2e testing.
+fitbit_user_poll_interval: 5000
+# -- How often to perform the main application loop (only controls how often to poll for new user registrations).
+# Only use to speed up processing times during e2e testing.
+application_loop_interval_ms: 300000
+# -- How often to invalidate the cache and poll for new user registrations.
+# Only use to speed up processing times during e2e testing.
+user_cache_refresh_interval_ms: 3600000


### PR DESCRIPTION
# Problem
At present the interval between refresh actions of the registered FitBit users is hard-coded and of very long (1hr). This makes using the FitBit connector in an e2e-test difficult.

# Solution
This PR will allow external configuration the 1) main application loop and 2) expiry of the FitBit user cache. This way e2e-tests can use shorter refresh intervals.