### PR TITLE
[radar-gateway] Add image registry config to exporter image

### DIFF
--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.0"
 description: A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 name: radar-gateway
-version: 1.4.0
+version: 1.4.1
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-gateway

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -3,7 +3,7 @@
 # radar-gateway
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-gateway)](https://artifacthub.io/packages/helm/radar-base/radar-gateway)
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 
@@ -43,6 +43,12 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | image.digest | string | `""` | Image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.pullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. e.g: pullSecrets:   - myRegistryKeySecretName |
+| image_exporter.registry | string | `"docker.io"` | Image registry |
+| image_exporter.repository | string | `"sscaling/jmx-prometheus-exporter"` | Image repository |
+| image_exporter.tag | string | `nil` | Image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |
+| image_exporter.digest | string | `"48e3bd31f132"` | Image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag |
+| image_exporter.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image_exporter.pullSecrets | list | `[]` | Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace. e.g: pullSecrets:   - myRegistryKeySecretName |
 | nameOverride | string | `""` | String to partially override radar-gateway.fullname template with a string (will prepend the release name) |
 | fullnameOverride | string | `""` | String to fully override radar-gateway.fullname template with a string |
 | podSecurityContext | object | `{}` | Configure radar-gateway pods' Security Context |

--- a/charts/radar-gateway/templates/_helpers.tpl
+++ b/charts/radar-gateway/templates/_helpers.tpl
@@ -14,6 +14,13 @@ Return the proper image name
 {{- end -}}
 
 {{/*
+Return the proper exporter image name
+*/}}
+{{- define "radar-gateway.image-exporter" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image_exporter "global" .Values.global "chart" .Chart ) }}
+{{- end -}}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "radar-gateway.imagePullSecrets" -}}

--- a/charts/radar-gateway/templates/deployment.yaml
+++ b/charts/radar-gateway/templates/deployment.yaml
@@ -43,10 +43,10 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
       {{- if .Values.serviceMonitor.enabled }}
-        - image: sscaling/jmx-prometheus-exporter
+        - image: {{ template "radar-gateway.image-exporter" . }}
+          imagePullPolicy: {{ .Values.image_exporter.pullPolicy | quote }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          imagePullPolicy: IfNotPresent
           name: prometheus-jmx-exporter
           env:
             - name: "CONFIG_YML"

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -25,6 +25,26 @@ image:
   #
   pullSecrets: []
 
+image_exporter:
+  # -- Image registry
+  registry: docker.io
+  # -- Image repository
+  repository: sscaling/jmx-prometheus-exporter
+  # -- Image tag (immutable tags are recommended)
+  # Overrides the image tag whose default is the chart appVersion.
+  tag:
+  # -- Image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  digest: "48e3bd31f132"
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Optionally specify an array of imagePullSecrets.
+  # Secrets must be manually created in the namespace.
+  # e.g:
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+  #
+  pullSecrets: []
+
 # -- String to partially override radar-gateway.fullname template with a string (will prepend the release name)
 nameOverride: ""
 # -- String to fully override radar-gateway.fullname template with a string


### PR DESCRIPTION
JMX exporter image didn't had the ability to configure image registry, this PR adds that feature.