### PR TITLE
[radar-gateway] Update radar-gateway helm chart for Opentelemetry config.

### DIFF
--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.8.0"
 description: A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 name: radar-gateway
-version: 1.4.4
+version: 1.5.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-gateway

--- a/charts/radar-gateway/Chart.yaml
+++ b/charts/radar-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.8.0"
+appVersion: "0.9.0"
 description: A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 name: radar-gateway
 version: 1.5.0

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -3,7 +3,7 @@
 # radar-gateway
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-gateway)](https://artifacthub.io/packages/helm/radar-base/radar-gateway)
 
-![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 
@@ -68,6 +68,7 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | nodeSelector | object | `{}` | Node labels for pod assignment |
 | tolerations | list | `[]` | Toleration labels for pod assignment |
 | affinity | object | `{}` | Affinity labels for pod assignment |
+| javaOpts | string | `"-XX:GCTimeRatio=19 -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=30 --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.management/javax.management.openmbean=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.management/javax.management=ALL-UNNAMED -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"` | Standard JAVA_OPTS that should be passed to this service |
 | extraEnvVars | list | `[]` | Extra environment variables |
 | customLivenessProbe | object | `{}` | Custom livenessProbe that overrides the default one |
 | livenessProbe.enabled | bool | `true` | Enable livenessProbe |
@@ -114,3 +115,9 @@ A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming partici
 | sentry.service.environment | string | `"production"` | Environment of the sentry service |
 | sentry.stacktrace.enabled | bool | `true` | Set to true, if stack trace should be enabled |
 | sentry.stacktrace.packages | string | `"org.radarbase.gateway,org.apache.avro"` | Comma-separated list of package prefixes to be included in the stacktrace |
+| openTelemetry.agent.enabled | bool | `false` | Enable OpenTelemetry agent (currently only Sentry agent is supported) |
+| openTelemetry.agent.agentJar | string | `"sentry-opentelemetry-agent-8.1.0.jar"` | OpenTelemetry Sentry agent jar file name, depends on version of 'io.sentry:sentry-opentelemetry-agent' |
+| openTelemetry.exporter.tracesSampleRate | float | `1` | Sample rate for traces (0.0 to 1.0) |
+| openTelemetry.exporter.metricsExporterEnabled | bool | `false` | Enable OpenTelemetry metrics exporter other than Sentry |
+| openTelemetry.exporter.tracesExporterEnabled | bool | `false` | Enable OpenTelemetry traces exporter other than Sentry |
+| openTelemetry.exporter.logsExporterEnabled | bool | `true` | Enable OpenTelemetry logs exporter other than Sentry |

--- a/charts/radar-gateway/README.md
+++ b/charts/radar-gateway/README.md
@@ -3,7 +3,7 @@
 # radar-gateway
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-gateway)](https://artifacthub.io/packages/helm/radar-base/radar-gateway)
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 A Helm chart for RADAR-base gateway. REST Gateway to Kafka, for incoming participant data. It performs authentication, authorization, content validation and decompression. For more details of the configurations, see https://github.com/RADAR-base/RADAR-Gateway/blob/master/gateway.yml.
 

--- a/charts/radar-gateway/templates/_helpers.tpl
+++ b/charts/radar-gateway/templates/_helpers.tpl
@@ -71,3 +71,14 @@ Create chart name and version as used by the chart label.
 {{- define "radar-gateway.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create JavaOpts string
+*/}}
+{{- define "radar-gateway.javaOpts" -}}
+{{- if and .Values.sentry.dsn .Values.openTelemetry.agent.enabled }}
+{{ printf "%s -javaagent:/usr/lib/%s" .Values.javaOpts .Values.openTelemetry.agent.agentJar }}
+{{- else -}}
+{{- .Values.javaOpts -}}
+{{- end -}}
+{{- end -}}

--- a/charts/radar-gateway/templates/deployment.yaml
+++ b/charts/radar-gateway/templates/deployment.yaml
@@ -67,15 +67,13 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command: ["radar-gateway", "/etc/radar-gateway/gateway.yml"]
           env:
-          - name: JAVA_OPTS
-            value: "-XX:GCTimeRatio=19 -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=30 --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.management/javax.management.openmbean=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.management/javax.management=ALL-UNNAMED -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
           {{- if .Values.sentry.dsn }}
           - name: SENTRY_DSN
             value: {{ .Values.sentry.dsn }}
           - name: SENTRY_LOG_LEVEL
             value: {{ .Values.sentry.level }}
             {{- if .Values.sentry.stacktrace.enabled }}
-          - name: SENTRY_ATTACH_STACKTRACE
+          - name: SENTRY_ATTACHSTACKTRACE
             value: {{ .Values.sentry.stacktrace.enabled | quote }}
           - name: SENTRY_STACKTRACE_APP_PACKAGES
             value: {{ .Values.sentry.stacktrace.packages}}
@@ -86,9 +84,31 @@ spec:
             value: {{ .Values.sentry.service.release | default (printf "%s-%s" .Chart.Version .Chart.AppVersion) }}
           - name: SENTRY_ENVIRONMENT
             value: {{ .Values.sentry.service.environment }}
+          {{- if .Values.openTelemetry.agent.enabled }}
+          - name: JAVA_OPTS
+            value: {{ printf "%s -javaagent:/usr/lib/%s" .Values.javaOpts .Values.openTelemetry.agent.agentJar | trimPrefix " " | quote }}
+          - name: SENTRY_TRACES_SAMPLE_RATE
+            value: {{ .Values.openTelemetry.exporter.tracesSampleRate | quote }}
+          {{- if eq .Values.openTelemetry.exporter.metricsExporterEnabled false }}
+          - name: OTEL_METRICS_EXPORTER
+            value: none
+          {{- end }}
+          {{- if eq .Values.openTelemetry.exporter.tracesExporterEnabled false}}
+          - name: OTEL_TRACES_EXPORTER
+            value: none
+          {{- end }}
+          {{- if eq .Values.openTelemetry.exporter.logsExporterEnabled false }}
+          - name: OTEL_LOGS_EXPORTER
+            value: none
+          {{- end }}
+          {{- end }}
           {{- else }}
           - name: SENTRY_ENABLED
             value: "false"
+          {{- end }}
+          {{- if or (not .Values.sentry.dsn) (and .Values.sentry.dsn (eq .Values.openTelemetry.agent.enabled false)) }}
+          - name: JAVA_OPTS
+            value: {{ .Values.javaOpts | quote }}
           {{- end }}
           {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 10 }}

--- a/charts/radar-gateway/templates/deployment.yaml
+++ b/charts/radar-gateway/templates/deployment.yaml
@@ -67,6 +67,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           command: ["radar-gateway", "/etc/radar-gateway/gateway.yml"]
           env:
+          - name: JAVA_OPTS
+            value: {{ include "radar-gateway.javaOpts" . }}
           {{- if .Values.sentry.dsn }}
           - name: SENTRY_DSN
             value: {{ .Values.sentry.dsn }}
@@ -84,31 +86,25 @@ spec:
             value: {{ .Values.sentry.service.release | default (printf "%s-%s" .Chart.Version .Chart.AppVersion) }}
           - name: SENTRY_ENVIRONMENT
             value: {{ .Values.sentry.service.environment }}
-          {{- if .Values.openTelemetry.agent.enabled }}
-          - name: JAVA_OPTS
-            value: {{ printf "%s -javaagent:/usr/lib/%s" .Values.javaOpts .Values.openTelemetry.agent.agentJar | trimPrefix " " | quote }}
+            {{- if .Values.openTelemetry.agent.enabled }}
           - name: SENTRY_TRACES_SAMPLE_RATE
             value: {{ .Values.openTelemetry.exporter.tracesSampleRate | quote }}
-          {{- if eq .Values.openTelemetry.exporter.metricsExporterEnabled false }}
+              {{- if not .Values.openTelemetry.exporter.metricsExporterEnabled }}
           - name: OTEL_METRICS_EXPORTER
             value: none
-          {{- end }}
-          {{- if eq .Values.openTelemetry.exporter.tracesExporterEnabled false}}
+              {{- end }}
+              {{- if not .Values.openTelemetry.exporter.tracesExporterEnabled }}
           - name: OTEL_TRACES_EXPORTER
             value: none
-          {{- end }}
-          {{- if eq .Values.openTelemetry.exporter.logsExporterEnabled false }}
+              {{- end }}
+              {{- if not .Values.openTelemetry.exporter.logsExporterEnabled }}
           - name: OTEL_LOGS_EXPORTER
             value: none
-          {{- end }}
-          {{- end }}
+              {{- end }}
+            {{- end }}
           {{- else }}
           - name: SENTRY_ENABLED
             value: "false"
-          {{- end }}
-          {{- if or (not .Values.sentry.dsn) (and .Values.sentry.dsn (eq .Values.openTelemetry.agent.enabled false)) }}
-          - name: JAVA_OPTS
-            value: {{ .Values.javaOpts | quote }}
           {{- end }}
           {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 10 }}

--- a/charts/radar-gateway/values.yaml
+++ b/charts/radar-gateway/values.yaml
@@ -126,6 +126,9 @@ tolerations: []
 # -- Affinity labels for pod assignment
 affinity: {}
 
+# -- Standard JAVA_OPTS that should be passed to this service
+javaOpts: "-XX:GCTimeRatio=19 -XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=30 --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.management/javax.management.openmbean=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.management/javax.management=ALL-UNNAMED -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
+
 # -- Extra environment variables
 extraEnvVars: []
 #  - name: BEARER_AUTH
@@ -289,3 +292,20 @@ sentry:
     enabled: true
     # -- Comma-separated list of package prefixes to be included in the stacktrace
     packages: "org.radarbase.gateway,org.apache.avro"
+
+# OpenTelemetry monitoring configuration
+openTelemetry:
+  agent:
+    # -- Enable OpenTelemetry agent (currently only Sentry agent is supported)
+    enabled: false
+    # -- OpenTelemetry Sentry agent jar file name, depends on version of 'io.sentry:sentry-opentelemetry-agent'
+    agentJar: sentry-opentelemetry-agent-8.1.0.jar
+  exporter:
+    # -- Sample rate for traces (0.0 to 1.0)
+    tracesSampleRate: 1.0
+    # -- Enable OpenTelemetry metrics exporter other than Sentry
+    metricsExporterEnabled: false
+    # -- Enable OpenTelemetry traces exporter other than Sentry
+    tracesExporterEnabled: false
+    # -- Enable OpenTelemetry logs exporter other than Sentry
+    logsExporterEnabled: true


### PR DESCRIPTION
Implements [RB-153](https://thehyve.atlassian.net/browse/RB-153)

Open Telemetry allows for distributed tracing of events in the RADARbase deployment. Sentry has support for Open Telemetry by including a sentry-opentelemetry-agent in each service in the deployment. 

This PR includes OpenTelemetry configuration with Sentry agent to radar-gateway.

Depends on https://github.com/RADAR-base/radar-commons/pull/181