### PR TITLE
fix: add missing hydra-maester external chart

### DIFF
--- a/charts/radar-hydra/Chart.yaml
+++ b/charts/radar-hydra/Chart.yaml
@@ -6,7 +6,7 @@ home: https://radar-base.org
 icon: http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-hydra
-version: 0.1.0
+version: 0.2.0
 maintainers:
   - email: pim@thehyve.nl
     name: Pim van Nierop
@@ -14,7 +14,7 @@ maintainers:
 type: application
 dependencies:
 - name: hydra
-  version: 0.52.1
+  version: 0.53.0
   repository: file://../../external/hydra
 - name: common
   repository: https://radar-base.github.io/radar-helm-charts

--- a/charts/radar-hydra/README.md
+++ b/charts/radar-hydra/README.md
@@ -3,7 +3,7 @@
 # hydra
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/hydra)](https://artifacthub.io/packages/helm/radar-base/hydra)
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
 
 A ORY Hydra Helm chart for RADAR-base. ORY Hydra is a cloud native Identity and User Management system.
 
@@ -33,7 +33,7 @@ Consult the [documentation](https://artifacthub.io/packages/helm/ory/hydra) of t
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../../external/hydra | hydra | 0.52.1 |
+| file://../../external/hydra | hydra | 0.53.0 |
 | https://radar-base.github.io/radar-helm-charts | common | 2.x.x |
 
 ## Values

--- a/external/hydra/Chart.lock
+++ b/external/hydra/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.1.0
 - name: hydra-maester
   repository: file://../hydra-maester
-  version: 0.52.1
-digest: sha256:0cfc98a2d01f11ceeb88805c4d70019931212920f48782d4953630ab235b0d6b
-generated: "2025-03-28T10:37:01.097142647Z"
+  version: 0.53.0
+digest: sha256:7b6f5f49aa7b2272b436300784f1f10fd68f5ce8af215a36a3a91affe4111c9b
+generated: "2025-04-08T10:00:45.876436876Z"

--- a/external/hydra/Chart.yaml
+++ b/external/hydra/Chart.yaml
@@ -9,7 +9,7 @@ dependencies:
   condition: maester.enabled
   name: hydra-maester
   repository: file://../hydra-maester
-  version: 0.52.1
+  version: 0.53.0
 description: A Helm chart for deploying ORY Hydra in Kubernetes
 home: https://www.ory.sh/
 icon: https://raw.githubusercontent.com/ory/docs/master/docs/static/img/logo-hydra.svg
@@ -30,4 +30,4 @@ sources:
 - https://github.com/ory/hydra
 - https://github.com/ory/k8s
 type: application
-version: 0.52.1
+version: 0.53.0

--- a/external/hydra/README.md
+++ b/external/hydra/README.md
@@ -1,6 +1,6 @@
 # hydra
 
-![Version: 0.52.0](https://img.shields.io/badge/Version-0.52.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
+![Version: 0.52.1](https://img.shields.io/badge/Version-0.52.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
 
 A Helm chart for deploying ORY Hydra in Kubernetes
 
@@ -21,7 +21,7 @@ A Helm chart for deploying ORY Hydra in Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../hydra-maester | hydra-maester(hydra-maester) | 0.52.0 |
+| file://../hydra-maester | hydra-maester(hydra-maester) | 0.52.1 |
 | file://../ory-commons | ory(ory-commons) | 0.1.0 |
 
 ## Values

--- a/external/hydra/charts/hydra-maester/Chart.yaml
+++ b/external/hydra/charts/hydra-maester/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/ory/docs/master/docs/static/img/logo-hydra.svg
 name: hydra-maester
 type: application
-version: 0.52.1
+version: 0.53.0

--- a/external/hydra/charts/hydra-maester/README.md
+++ b/external/hydra/charts/hydra-maester/README.md
@@ -1,6 +1,6 @@
 # hydra-maester
 
-![Version: 0.52.0](https://img.shields.io/badge/Version-0.52.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.36](https://img.shields.io/badge/AppVersion-v0.0.36-informational?style=flat-square)
+![Version: 0.52.1](https://img.shields.io/badge/Version-0.52.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.36](https://img.shields.io/badge/AppVersion-v0.0.36-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/external/hydra/templates/_helpers.tpl
+++ b/external/hydra/templates/_helpers.tpl
@@ -133,10 +133,10 @@ Generate the urls.issuer value
 */}}
 {{- define "hydra.config.urls.issuer" -}}
 {{- if .Values.hydra.config.urls.self.issuer -}}
-{{- .Values.hydra.config.urls.self.issuer }}
+{{- tpl .Values.hydra.config.urls.self.issuer $ }}
 {{- else if .Values.ingress.public.enabled -}}
 {{- $host := index .Values.ingress.public.hosts 0 -}}
-http{{ if $.Values.ingress.public.tls }}s{{ end }}://{{ $host.host }}
+http{{ if $.Values.ingress.public.tls }}s{{ end }}://{{ tpl $host.host $ }}
 {{- else if contains "ClusterIP" .Values.service.public.type -}}
 http://127.0.0.1:{{ .Values.service.public.port }}/
 {{- end -}}

--- a/external/hydra/templates/ingress-admin.yaml
+++ b/external/hydra/templates/ingress-admin.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "hydra.labels" . | nindent 4 }}
   {{- with .Values.ingress.admin.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.admin.className }}
@@ -24,14 +24,14 @@ spec:
     {{- range .Values.ingress.admin.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.admin.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/external/hydra/templates/ingress-public.yaml
+++ b/external/hydra/templates/ingress-public.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "hydra.labels" . | nindent 4 }}
   {{- with .Values.ingress.public.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.public.className }}
@@ -24,14 +24,14 @@ spec:
     {{- range .Values.ingress.public.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
       secretName: {{ .secretName }}
-    {{- end }}  
+    {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.public.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}


### PR DESCRIPTION
In the previous commit I omitted the hydra-maester subchart for  the external hydra chart. This PR:

1. Updates the external-hydra chart to v0.53.0
2. Adds the missing hydra-maester sub-chart.