### PR TITLE
Fix: persist-secrets-between-updates

### DIFF
--- a/charts/radar-cloudnative-postgresql/Chart.yaml
+++ b/charts/radar-cloudnative-postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: radar-cloudnative-postgresql
-version: 0.2.2
+version: 0.2.3
 description: CloudNativePG Postgresql helm chart for RADAR-base
 home: https://radar-base.org
 icon: http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png

--- a/charts/radar-cloudnative-postgresql/README.md
+++ b/charts/radar-cloudnative-postgresql/README.md
@@ -3,7 +3,7 @@
 # radar-cloudnative-postgresql
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-cloudnative-postgresql)](https://artifacthub.io/packages/helm/radar-base/radar-cloudnative-postgresql)
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square)
 
 CloudNativePG Postgresql helm chart for RADAR-base
 
@@ -42,5 +42,8 @@ for additional information on how to configure the operator if needed.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| secrets | list | check values.yaml | Random database password secrets will be created for these users. |
+| secret | object | `{"enabled":true,"nameOverride":"","secretAnnotations":{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"0","helm.sh/resource-policy":"keep"},"users":[{"dbname":"managementportal","user":"managementportal"},{"dbname":"restsourceauthorizer","user":"restsourceauthorizer"},{"dbname":"appconfig","user":"appconfig"},{"dbname":"kratos","user":"kratos"},{"dbname":"hydra","user":"hydra"},{"dbname":"appserver","user":"appserver"},{"dbname":"uploadconnector","user":"uploadconnector"}]}` | Values for creating the database user secretsl |
+| secret.enabled | bool | `true` | Switch to false to prevent creating user secrets. |
+| secret.secretAnnotations | object | `{"helm.sh/hook":"pre-install, pre-upgrade","helm.sh/hook-delete-policy":"before-hook-creation","helm.sh/hook-weight":"0","helm.sh/resource-policy":"keep"}` | Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified. |
+| secret.users | list | check values.yaml | Random database password secrets will be created for these users. |
 | cluster | object | check `values.yaml` | CloudNativePG configuration |

--- a/charts/radar-cloudnative-postgresql/templates/_helpers.tpl
+++ b/charts/radar-cloudnative-postgresql/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "radar-cloudnativepg-postgresql.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "radar-cloudnativepg-postgresql.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "radar-cloudnativepg-postgresql.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "radar-cloudnativepg-postgresql.labels" -}}
+app.kubernetes.io/name: {{ include "radar-cloudnativepg-postgresql.name" . }}
+helm.sh/chart: {{ include "radar-cloudnativepg-postgresql.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create a secret name which can be overridden.
+*/}}
+{{- define "radar-cloudnativepg-postgresql.secretname" -}}
+{{- if .Values.secret.nameOverride -}}
+{{- .Values.secret.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{ include "radar-cloudnativepg-postgresql.fullname" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Set value from existing secret if defined
+I tried using "common.secrets.password.manage" but it gives errors on helm upgrades.
+Arguments (dict):
+- secret: the name of the secret
+- key: the key in the secret
+- contxt: global/root helm context
+*/}}
+{{- define "radar-cloudnativepg-postgresql.secret.value" -}}
+{{- $secretObj := (lookup "v1" "Secret" .context.Release.Namespace .secret) | default dict }}
+{{- $secretData := (get $secretObj "data") | default dict }}
+{{- get $secretData .key | b64dec }}
+{{- end -}}

--- a/charts/radar-cloudnative-postgresql/templates/secret-users.yaml
+++ b/charts/radar-cloudnative-postgresql/templates/secret-users.yaml
@@ -1,16 +1,25 @@
-{{- $top := . }}
-{{- $host := printf "%s-cluster-rw.default" $top.Release.Name }}
+{{- if .Values.secret.enabled }}
+{{- $host := printf "%s-cluster-rw.default" $.Release.Name }}
 {{- $port := "5432" }}
-{{- range .Values.secrets }}
+{{- range .Values.secret.users }}
 ---
-{{- $secretName := printf "%s-%s" $top.Release.Name .user }}
-{{- $password := (include "common.secrets.passwords.manage" (dict "secret" $secretName "key" "password" "length" 65 "providedValues" (list ) "skipQuote" "true" "skipB64enc" "true" "context" $top)) }}
+{{- $secretName := printf "%s-%s" (include "radar-cloudnativepg-postgresql.secretname" $) .user }}
+{{- $password := include "radar-cloudnativepg-postgresql.secret.value" (dict "secret" $secretName "key" "password" "context" $) | default (randAlphaNum 65) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
   labels:
     cnpg.io/reload: "true"
+  {{- if or $.Values.commonAnnotations $.Values.secret.secretAnnotations }}
+  annotations:
+  {{- if $.Values.commonAnnotations }}
+  {{- include "common.tplvalues.render" (dict "value" $.Values.commonAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if $.Values.secret.secretAnnotations }}
+  {{- include "common.tplvalues.render" (dict "value" $.Values.secret.secretAnnotations "context" $) | nindent 4 }}
+  {{- end }}
+  {{- end }}
 type: kubernetes.io/basic-auth
 data:
   name: {{ .user | b64enc | quote }}
@@ -21,4 +30,5 @@ data:
   port: {{ $port | b64enc }}
   uri: {{ (printf "postgresql://%s:%s@%s:%s/%s" .user $password $host $port .dbname) | b64enc | quote }}
   jdbc-uri: {{ (printf "jdbc:postgresql://%s:%s/%s?password=%s&user=%s" $host $port .dbname $password .user) | b64enc | quote }}
-{{ end }}
+{{- end }}
+{{- end }}

--- a/charts/radar-cloudnative-postgresql/values.yaml
+++ b/charts/radar-cloudnative-postgresql/values.yaml
@@ -1,6 +1,19 @@
-# -- Random database password secrets will be created for these users.
-# @default -- check values.yaml
-secrets:
+# -- Values for creating the database user secretsl
+secret:
+  # -- Switch to false to prevent creating user secrets.
+  enabled: true
+  nameOverride: ""
+  # -- Annotations to be added to secret. Annotations are added only when secret is being created. Existing secret will not be modified.
+  secretAnnotations:
+    # Create the secret before installation, and only then. This saves the secret from regenerating during an upgrade
+    # pre-upgrade is needed to upgrade from 0.7.0 to newer. Can be deleted afterwards.
+    helm.sh/hook-weight: "0"
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/resource-policy: keep
+  # -- Random database password secrets will be created for these users.
+  # @default -- check values.yaml
+  users:
   - user: managementportal
     dbname: managementportal
   - user: restsourceauthorizer

--- a/charts/radar-self-enrolment-ui/Chart.yaml
+++ b/charts/radar-self-enrolment-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.0.1"
 description: A Helm chart for RADAR-base Self Enrolment UI
 name: radar-self-enrolment-ui
-version: 0.2.3
+version: 0.2.4
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-self-enrolment-ui

--- a/charts/radar-self-enrolment-ui/README.md
+++ b/charts/radar-self-enrolment-ui/README.md
@@ -2,7 +2,7 @@
 
 # radar-self-enrolment-ui
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart for RADAR-base Self Enrolment UI
 

--- a/charts/radar-self-enrolment-ui/templates/_helpers.tpl
+++ b/charts/radar-self-enrolment-ui/templates/_helpers.tpl
@@ -68,3 +68,17 @@ Create a secret name which can be overridden.
 {{ include "radar-self-enrolment-ui.fullname" . }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Set value from existing secret if defined
+I tried using "common.secrets.password.manage" but it gives errors on helm upgrades.
+Arguments (dict):
+- secret: the name of the secret
+- key: the key in the secret
+- contxt: global/root helm context
+*/}}
+{{- define "radar-self-enrolment-ui.secret.value" -}}
+{{- $secretObj := (lookup "v1" "Secret" .context.Release.Namespace .secret) | default dict }}
+{{- $secretData := (get $secretObj "data") | default dict }}
+{{- get $secretData .key | b64dec }}
+{{- end -}}

--- a/charts/radar-self-enrolment-ui/templates/secret.yaml
+++ b/charts/radar-self-enrolment-ui/templates/secret.yaml
@@ -1,19 +1,24 @@
 {{- if .Values.secret.enabled -}}
+{{- $secretName := include "radar-self-enrolment-ui.secretname" . }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ $secretName }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.secret.secretAnnotations }}
+  annotations:
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.secret.secretAnnotations }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.secret.secretAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
   {{- end }}
 type: Opaque
 data:
-  # Generate a random secret if the user doesn't give one. User given secret has priority
-  {{- $cookieSecretName := printf "%s-%s" (include "common.names.fullname" .) "csrf-cookie" }}
-  {{- $cookieSecret := include "common.secrets.passwords.manage" (dict "secret" $cookieSecretName "key" "cookieSecret" "providedValues" (list ) "length" 32 "skipQuote" "true" "skipB64enc" "true" "context" $) }}
-  {{- $cookieCsrfSecret := include "common.secrets.passwords.manage" (dict "secret" $cookieSecretName "key" "cookieCsrfSecret" "providedValues" (list ) "length" 32 "skipQuote" "true" "skipB64enc" "true" "context" $) }}
-  secretsCookie: {{ ( .Values.config.secrets.cookie | default $cookieSecret) | required "Value config.secrets.cookie can not be empty!" | b64enc | quote }}
-  secretsCSRFCookie: {{ ( .Values.config.secrets.csrfCookie | default $cookieCsrfSecret) | required "Value config.secrets.csrfCookie can not be empty!" | b64enc | quote }}
+  {{- $secretsCookie := include "radar-self-enrolment-ui.secret.value" (dict "secret" $secretName "key" "secretsCookie" "context" .) | default (randAlphaNum 32) }}
+  secretsCookie: {{ ( .Values.config.secrets.cookie | default $secretsCookie) | b64enc | quote }}
+  {{- $secretsCSRFCookie := include "radar-self-enrolment-ui.secret.value" (dict "secret" $secretName "key" "secretsCSRFCookie" "context" .) | default (randAlphaNum 32) }}
+  secretsCSRFCookie: {{ ( .Values.config.secrets.csrfCookie | default $secretsCSRFCookie) | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
In the chart updates for _self-enrolment-portal_ and _cloudnative-postgresql_ random generation of secrets was implemented incorrectly (error between redeploys). This PR corrects this problem by:

1. Removal of the incorrect use of the `common.secrets.password.manage` function.
2. Implement correct password generation logic for persistence of pre-extisting secrets.