### PR TITLE
[radar-rest-connectors] Allow configurable auth_url

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint-artifacthub:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: artifacthub/ah
       options: --user root

--- a/charts/radar-fitbit-connector/Chart.yaml
+++ b/charts/radar-fitbit-connector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.6.1
 description: A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 name: radar-fitbit-connector
-version: 0.7.3
+version: 0.7.4
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-fitbit-connector

--- a/charts/radar-fitbit-connector/Chart.yaml
+++ b/charts/radar-fitbit-connector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.6.1
+appVersion: 0.6.2
 description: A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 name: radar-fitbit-connector
 version: 0.7.4

--- a/charts/radar-fitbit-connector/README.md
+++ b/charts/radar-fitbit-connector/README.md
@@ -91,6 +91,7 @@ A Helm chart for RADAR-base fitbit connector. This application collects data fro
 | auth_url | string | `"http://management-portal:8080/managementportal/oauth/token"` | OAuth2 Auth URL for connector client to get access tokens |
 | managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of Management Portal. This will be used to create URLs to access Management Portal |
 | includeIntradayData | bool | `true` | Set to true, if intraday access data should be collected by the connector. This will be set in connector.properties. |
+| user_repository_class | string | `"ServiceUserRepositoryLegacy"` | Class of the user repository to use. This should be a class that implements the UserRepository interface. |
 | rest_source_poll_interval_ms | int | `60000` | How often to poll the source URL. Only use to speed up processing times during e2e testing. |
 | fitbit_user_poll_interval | int | `5000` | Polling interval per Fitbit user per request route in seconds. Only use to speed up processing times during e2e testing. |
 | application_loop_interval_ms | int | `300000` | How often to perform the main application loop (only controls how often to poll for new user registrations). Only use to speed up processing times during e2e testing. |

--- a/charts/radar-fitbit-connector/README.md
+++ b/charts/radar-fitbit-connector/README.md
@@ -3,7 +3,7 @@
 # radar-fitbit-connector
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-fitbit-connector)](https://artifacthub.io/packages/helm/radar-base/radar-fitbit-connector)
 
-![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.2](https://img.shields.io/badge/AppVersion-0.6.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 

--- a/charts/radar-fitbit-connector/README.md
+++ b/charts/radar-fitbit-connector/README.md
@@ -3,7 +3,7 @@
 # radar-fitbit-connector
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-fitbit-connector)](https://artifacthub.io/packages/helm/radar-base/radar-fitbit-connector)
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
 
 A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 
@@ -88,6 +88,7 @@ A Helm chart for RADAR-base fitbit connector. This application collects data fro
 | fitbit_api_secret | string | `""` | Fitbit API client secret. |
 | oauthClientId | string | `"radar_fitbit_connector"` | OAuth2 client id from Management Portal |
 | oauthClientSecret | string | `"secret"` | OAuth2 client secret from Management Portal |
+| auth_url | string | `"http://management-portal:8080/managementportal/oauth/token"` | OAuth2 Auth URL for connector client to get access tokens |
 | managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of Management Portal. This will be used to create URLs to access Management Portal |
 | includeIntradayData | bool | `true` | Set to true, if intraday access data should be collected by the connector. This will be set in connector.properties. |
 | rest_source_poll_interval_ms | int | `60000` | How often to poll the source URL. Only use to speed up processing times during e2e testing. |

--- a/charts/radar-fitbit-connector/templates/configmap-properties.yaml
+++ b/charts/radar-fitbit-connector/templates/configmap-properties.yaml
@@ -22,7 +22,7 @@ data:
     fitbit.user.repository.url={{ .Values.radar_rest_sources_backend_url }}
     fitbit.user.repository.client.id={{ .Values.oauthClientId }}
     fitbit.user.repository.client.secret={{ .Values.oauthClientSecret }}
-    fitbit.user.repository.oauth2.token.url={{ .Values.managementportal_url }}/oauth/token
+    fitbit.user.repository.oauth2.token.url={{ .Values.auth_url }}
     fitbit.user.poll.interval={{ .Values.fitbit_user_poll_interval | int }}
     application.loop.interval.ms={{ .Values.application_loop_interval_ms | int }}
     user.cache.refresh.interval.ms={{ .Values.user_cache_refresh_interval_ms | int}}

--- a/charts/radar-fitbit-connector/templates/configmap-properties.yaml
+++ b/charts/radar-fitbit-connector/templates/configmap-properties.yaml
@@ -18,7 +18,7 @@ data:
     fitbit.api.client={{ .Values.fitbit_api_client }}
     fitbit.api.secret={{ .Values.fitbit_api_secret }}
     fitbit.api.intraday={{ .Values.includeIntradayData }}
-    fitbit.user.repository.class=org.radarbase.connect.rest.fitbit.user.ServiceUserRepository
+    fitbit.user.repository.class=org.radarbase.connect.rest.fitbit.user.{{ .Values.user_repository_class }}
     fitbit.user.repository.url={{ .Values.radar_rest_sources_backend_url }}
     fitbit.user.repository.client.id={{ .Values.oauthClientId }}
     fitbit.user.repository.client.secret={{ .Values.oauthClientSecret }}

--- a/charts/radar-fitbit-connector/values.yaml
+++ b/charts/radar-fitbit-connector/values.yaml
@@ -232,6 +232,8 @@ managementportal_url: http://management-portal:8080/managementportal
 # -- Set to true, if intraday access data should be collected by the connector. This will be set in connector.properties.
 includeIntradayData: true
 
+# -- Class of the user repository to use. This should be a class that implements the UserRepository interface.
+user_repository_class: ServiceUserRepositoryLegacy
 
 # -- How often to poll the source URL.
 # Only use to speed up processing times during e2e testing.

--- a/charts/radar-fitbit-connector/values.yaml
+++ b/charts/radar-fitbit-connector/values.yaml
@@ -225,6 +225,8 @@ fitbit_api_secret: ""
 oauthClientId: radar_fitbit_connector
 # -- OAuth2 client secret from Management Portal
 oauthClientSecret: secret
+# -- OAuth2 Auth URL for connector client to get access tokens
+auth_url: http://management-portal:8080/managementportal/oauth/token
 # -- URL of Management Portal. This will be used to create URLs to access Management Portal
 managementportal_url: http://management-portal:8080/managementportal
 # -- Set to true, if intraday access data should be collected by the connector. This will be set in connector.properties.

--- a/charts/radar-oura-connector/Chart.yaml
+++ b/charts/radar-oura-connector/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.6.1
+appVersion: 0.6.2
 description: A Helm chart for RADAR-base oura connector. This application collects data from participants via the Oura Web API.
 name: radar-oura-connector
 version: 0.2.4

--- a/charts/radar-oura-connector/Chart.yaml
+++ b/charts/radar-oura-connector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.6.1
 description: A Helm chart for RADAR-base oura connector. This application collects data from participants via the Oura Web API.
 name: radar-oura-connector
-version: 0.2.3
+version: 0.2.4
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-oura-connector

--- a/charts/radar-oura-connector/README.md
+++ b/charts/radar-oura-connector/README.md
@@ -3,7 +3,7 @@
 # radar-oura-connector
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-oura-connector)](https://artifacthub.io/packages/helm/radar-base/radar-oura-connector)
 
-![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.2](https://img.shields.io/badge/AppVersion-0.6.2-informational?style=flat-square)
 
 A Helm chart for RADAR-base oura connector. This application collects data from participants via the Oura Web API.
 

--- a/charts/radar-oura-connector/README.md
+++ b/charts/radar-oura-connector/README.md
@@ -91,3 +91,4 @@ A Helm chart for RADAR-base oura connector. This application collects data from 
 | auth_url | string | `"http://management-portal:8080/managementportal/oauth/token"` | OAuth2 Auth URL for connector client to get access tokens |
 | managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of Management Portal. This will be used to create URLs to access Management Portal |
 | includeIntradayData | bool | `true` | Set to true, if intraday access data should be collected by the connector. This will be set in connector.properties. |
+| user_repository_class | string | `"OuraServiceUserRepositoryLegacy"` | Class name of the user repository. This should be the same as the one used in the connector. |

--- a/charts/radar-oura-connector/README.md
+++ b/charts/radar-oura-connector/README.md
@@ -3,7 +3,7 @@
 # radar-oura-connector
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-oura-connector)](https://artifacthub.io/packages/helm/radar-base/radar-oura-connector)
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.1](https://img.shields.io/badge/AppVersion-0.6.1-informational?style=flat-square)
 
 A Helm chart for RADAR-base oura connector. This application collects data from participants via the Oura Web API.
 
@@ -88,5 +88,6 @@ A Helm chart for RADAR-base oura connector. This application collects data from 
 | oura_api_secret | string | `""` | Oura API client secret. |
 | oauthClientId | string | `"radar_oura_connector"` | OAuth2 client id from Management Portal |
 | oauthClientSecret | string | `"secret"` | OAuth2 client secret from Management Portal |
+| auth_url | string | `"http://management-portal:8080/managementportal/oauth/token"` | OAuth2 Auth URL for connector client to get access tokens |
 | managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of Management Portal. This will be used to create URLs to access Management Portal |
 | includeIntradayData | bool | `true` | Set to true, if intraday access data should be collected by the connector. This will be set in connector.properties. |

--- a/charts/radar-oura-connector/templates/configmap-properties.yaml
+++ b/charts/radar-oura-connector/templates/configmap-properties.yaml
@@ -17,7 +17,7 @@ data:
     oura.api.client={{ .Values.oura_api_client }}
     oura.api.secret={{ .Values.oura_api_secret }}
     oura.api.intraday={{ .Values.includeIntradayData }}
-    oura.user.repository.class=org.radarbase.connect.rest.oura.user.OuraServiceUserRepository
+    oura.user.repository.class=org.radarbase.connect.rest.oura.user.{{ .Values.user_repository_class }}
     oura.user.repository.url={{ .Values.radar_rest_sources_backend_url }}
     oura.user.repository.client.id={{ .Values.oauthClientId }}
     oura.user.repository.client.secret={{ .Values.oauthClientSecret }}

--- a/charts/radar-oura-connector/templates/configmap-properties.yaml
+++ b/charts/radar-oura-connector/templates/configmap-properties.yaml
@@ -21,7 +21,7 @@ data:
     oura.user.repository.url={{ .Values.radar_rest_sources_backend_url }}
     oura.user.repository.client.id={{ .Values.oauthClientId }}
     oura.user.repository.client.secret={{ .Values.oauthClientSecret }}
-    oura.user.repository.oauth2.token.url={{ .Values.managementportal_url }}/oauth/token
+    oura.user.repository.oauth2.token.url={{ .Values.auth_url }}
   {{- if and .Values.kafka_wait.enabled .Values.kafka_wait.properties }}
   kafka-wait.properties: |
     {{ .Values.kafka_wait.properties | indent 4 }}

--- a/charts/radar-oura-connector/values.yaml
+++ b/charts/radar-oura-connector/values.yaml
@@ -226,3 +226,6 @@ auth_url: http://management-portal:8080/managementportal/oauth/token
 managementportal_url: http://management-portal:8080/managementportal
 # -- Set to true, if intraday access data should be collected by the connector. This will be set in connector.properties.
 includeIntradayData: true
+
+# -- Class name of the user repository. This should be the same as the one used in the connector.
+user_repository_class: OuraServiceUserRepositoryLegacy

--- a/charts/radar-oura-connector/values.yaml
+++ b/charts/radar-oura-connector/values.yaml
@@ -220,6 +220,8 @@ oura_api_secret: ""
 oauthClientId: radar_oura_connector
 # -- OAuth2 client secret from Management Portal
 oauthClientSecret: secret
+# -- OAuth2 Auth URL for connector client to get access tokens
+auth_url: http://management-portal:8080/managementportal/oauth/token
 # -- URL of Management Portal. This will be used to create URLs to access Management Portal
 managementportal_url: http://management-portal:8080/managementportal
 # -- Set to true, if intraday access data should be collected by the connector. This will be set in connector.properties.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of maintainers might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
- Allow configurable `auth_url` in both `radar-fitbit-connector` and `radar-oura-connector` for deployments that use Hydra auth (default is still MP auth url)
- Currently manually updated in deployments, but would be good to have this configurable in the chart itself

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
- Allows Hydra auth
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**
- Depends on https://github.com/RADAR-base/RADAR-REST-Connector/pull/163

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
