### PR TITLE
fix: jdbc-connector database service name

### DIFF
--- a/charts/radar-jdbc-connector/Chart.yaml
+++ b/charts/radar-jdbc-connector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 10.8.0
 name: radar-jdbc-connector
 description: A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
-version: 0.9.0
+version: 0.9.1
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-jdbc-connector

--- a/charts/radar-jdbc-connector/README.md
+++ b/charts/radar-jdbc-connector/README.md
@@ -3,7 +3,7 @@
 # radar-jdbc-connector
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-jdbc-connector)](https://artifacthub.io/packages/helm/radar-base/radar-jdbc-connector)
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.8.0](https://img.shields.io/badge/AppVersion-10.8.0-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.8.0](https://img.shields.io/badge/AppVersion-10.8.0-informational?style=flat-square)
 
 A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
 

--- a/charts/radar-jdbc-connector/templates/_helpers.tpl
+++ b/charts/radar-jdbc-connector/templates/_helpers.tpl
@@ -143,8 +143,8 @@ Construct the Cloudnative-PG database URL
 {{- $dbConfig := .Values.timescaledb.cluster }}
 {{- $dbname := $dbConfig.cluster.initdb.database | default "postgres" }}
 {{- $override := $dbConfig.nameOverride | default "cluster" }}
-{{- $host := printf "%s-%s-rw.default" .Release.Name $override }}
-{{- printf "jdbc:postgresql://%s:%d/%s" $host $port $dbname -}}
+{{- $dbServiceName :=  $dbConfig.fullnameOverride | default (printf "%s-%s" .Release.Name $override) -}}
+{{- printf "jdbc:postgresql://%s-rw.default:%d/%s" $dbServiceName $port $dbname -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Fix the the helm template function that derives the hostname for db connection in case a fullnameOverride is used.