### PR TITLE
feat: configure fitbit connector users file from values

### DIFF
--- a/charts/radar-fitbit-connector/Chart.yaml
+++ b/charts/radar-fitbit-connector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 0.7.0
 description: A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 name: radar-fitbit-connector
-version: 0.9.3
+version: 0.10.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-fitbit-connector

--- a/charts/radar-fitbit-connector/README.md
+++ b/charts/radar-fitbit-connector/README.md
@@ -3,7 +3,7 @@
 # radar-fitbit-connector
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-fitbit-connector)](https://artifacthub.io/packages/helm/radar-base/radar-fitbit-connector)
 
-![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 A Helm chart for RADAR-base fitbit connector. This application collects data from participants via the Fitbit Web API.
 
@@ -106,3 +106,15 @@ A Helm chart for RADAR-base fitbit connector. This application collects data fro
 | application_loop_interval_ms | int | `300000` | How often to perform the main application loop (only controls how often to poll for new user registrations). Only use to speed up processing times during e2e testing. |
 | user_cache_refresh_interval_ms | int | `3600000` | How often to invalidate the cache and poll for new user registrations. Only use to speed up processing times during e2e testing. |
 | routes | object | `{"activityLog":{"enabled":true,"topic":"connect_fitbit_activity_log"},"breathingRate":{"enabled":true,"topic":"connect_fitbit_breathing_rate"},"intradayCalories":{"enabled":true,"topic":"connect_fitbit_intraday_calories"},"intradayHeartRate":{"enabled":true,"topic":"connect_fitbit_intraday_heart_rate"},"intradayHeartRateVariability":{"enabled":true,"topic":"connect_fitbit_intraday_heart_rate_variability"},"intradaySpo2":{"enabled":true,"topic":"connect_fitbit_intraday_spo2"},"intradaySteps":{"enabled":true,"topic":"connect_fitbit_intraday_steps"},"restingHeartRate":{"enabled":true,"topic":"connect_fitbit_resting_heart_rate"},"skinTemperature":{"enabled":true,"topic":"connect_fitbit_skin_temperature"},"sleepClassic":{"enabled":true,"topic":"connect_fitbit_sleep_classic"},"sleepStages":{"enabled":true,"topic":"connect_fitbit_sleep_stages"},"timezone":{"enabled":true,"topic":"connect_fitbit_timezone"}}` | Whether to include the specific routes and to specify the topics to use for each route. |
+| usersFile | object | `{"users":[{"endDate":"2019-01-01T00:00:00Z","externalUserId":"?","id":"test","oauth2":{"accessToken":"?","expiresAt":"2018-08-06T00:00:00Z","refreshToken":"?"},"projectId":"radar-test","sourceId":"charge-2","startDate":"2018-08-06T00:00:00Z","userId":"test"}]}` | Only used when user_repository_class is YamlUserRepository |
+| usersFile.users | list | `[{"endDate":"2019-01-01T00:00:00Z","externalUserId":"?","id":"test","oauth2":{"accessToken":"?","expiresAt":"2018-08-06T00:00:00Z","refreshToken":"?"},"projectId":"radar-test","sourceId":"charge-2","startDate":"2018-08-06T00:00:00Z","userId":"test"}]` | Users to be included in the users yaml file. |
+| usersFile.users[0] | object | `{"endDate":"2019-01-01T00:00:00Z","externalUserId":"?","id":"test","oauth2":{"accessToken":"?","expiresAt":"2018-08-06T00:00:00Z","refreshToken":"?"},"projectId":"radar-test","sourceId":"charge-2","startDate":"2018-08-06T00:00:00Z","userId":"test"}` | Unique user key |
+| usersFile.users[0].projectId | string | `"radar-test"` | Project ID to be used in org.radarcns.kafka.ObservationKey record keys |
+| usersFile.users[0].userId | string | `"test"` | User ID to be used in org.radarcns.kafka.ObservationKey record keys |
+| usersFile.users[0].sourceId | string | `"charge-2"` | Source ID to be used in org.radarcns.kafka.ObservationKey record keys |
+| usersFile.users[0].startDate | string | `"2018-08-06T00:00:00Z"` | Date from when to collect data. |
+| usersFile.users[0].endDate | string | `"2019-01-01T00:00:00Z"` | Date until when to collect data. |
+| usersFile.users[0].externalUserId | string | `"?"` | Fitbit user ID as returned by the Fitbit authentication procedure |
+| usersFile.users[0].oauth2.accessToken | string | `"?"` | Fitbit OAuth 2.0 access token as returned by the Fitbit authentication procedure |
+| usersFile.users[0].oauth2.refreshToken | string | `"?"` | Fitbit OAuth 2.0 refresh token as returned by the Fitbit authentication procedure |
+| usersFile.users[0].oauth2.expiresAt | string | `"2018-08-06T00:00:00Z"` | Optional expiry time of the access token. If absent, it will be estimated to one hour when the source connector starts. When an authentication error occurs, a new access token will be fetched regardless of the value in this field. |

--- a/charts/radar-fitbit-connector/templates/configmap-users.yaml
+++ b/charts/radar-fitbit-connector/templates/configmap-users.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.user_repository_class "YamlUserRepository" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,27 +10,22 @@ metadata:
   {{- end }}
 data:
   fitbit-user.yml: |
+  {{- range .Values.usersFile.users }}
     ---
-    # Unique user key
-    id: test
-    # Project ID to be used in org.radarcns.kafka.ObservationKey record keys
-    projectId: radar-test
-    # User ID to be used in org.radarcns.kafka.ObservationKey record keys
-    userId: test
-    # Source ID to be used in org.radarcns.kafka.ObservationKey record keys
-    sourceId: charge-2
-    # Date from when to collect data.
-    startDate: 2018-08-06T00:00:00Z
-    # Date until when to collect data.
-    endDate: 2019-01-01T00:00:00Z
-    # Fitbit user ID as returned by the Fitbit authentication procedure
-    externalUserId: ?
+    id: {{ .id }}
+    projectId: {{ .projectId }}
+    userId: {{ .userId }}
+    sourceId: {{ .sourceId }}
+    startDate: {{ .startDate }}
+    endDate: {{ .endDate }}
+    externalUserId: {{ .externalUserId }}
+    {{- with .oauth2 }}
     oauth2:
-      # Fitbit OAuth 2.0 access token as returned by the Fitbit authentication procedure
-      accessToken: ?
-      # Fitbit OAuth 2.0 refresh token as returned by the Fitbit authentication procedure
-      refreshToken: ?
-      # Optional expiry time of the access token. If absent, it will be estimated to one hour
-      # when the source connector starts. When an authentication error occurs, a new access token will
-      # be fetched regardless of the value in this field.
-      #expiresAt: 2018-08-06T00:00:00Z
+      accessToken: {{ .accessToken }}
+      refreshToken: {{ .refreshToken }}
+      {{- if .expiresAt }}
+      expiresAt: {{ .expiresAt }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/radar-fitbit-connector/templates/deployment.yaml
+++ b/charts/radar-fitbit-connector/templates/deployment.yaml
@@ -175,8 +175,10 @@ spec:
           volumeMounts:
             - name: config-properties
               mountPath: /etc/kafka-connect/source-fitbit
+            {{- if eq .Values.user_repository_class "YamlUserRepository" }}
             - name: config-users
               mountPath: /var/lib/kafka-connect-fitbit-source/users
+            {{- end }}
             - name: logs
               mountPath: /var/lib/kafka-connect-fitbit-source/logs
       {{- if .Values.persistence.fsUserOverride }}
@@ -197,9 +199,12 @@ spec:
         - name: config-properties
           configMap:
             name: {{ include "radar-fitbit-connector.fullname" . }}-properties
+        {{- if eq .Values.user_repository_class "YamlUserRepository" }}
         - name: config-users
           configMap:
             name: {{ include "radar-fitbit-connector.fullname" . }}-users
+            defaultMode: 0666
+        {{- end }}
         - name: logs
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/charts/radar-fitbit-connector/values.yaml
+++ b/charts/radar-fitbit-connector/values.yaml
@@ -310,3 +310,31 @@ routes:
   skinTemperature:
     enabled: true
     topic: "connect_fitbit_skin_temperature"
+
+# -- Only used when user_repository_class is YamlUserRepository
+usersFile:
+  # -- Users to be included in the users yaml file.
+  users:
+      # -- Unique user key
+    - id: test
+      # -- Project ID to be used in org.radarcns.kafka.ObservationKey record keys
+      projectId: radar-test
+      # -- User ID to be used in org.radarcns.kafka.ObservationKey record keys
+      userId: test
+      # -- Source ID to be used in org.radarcns.kafka.ObservationKey record keys
+      sourceId: charge-2
+      # -- Date from when to collect data.
+      startDate: 2018-08-06T00:00:00Z
+      # -- Date until when to collect data.
+      endDate: 2019-01-01T00:00:00Z
+      # --Fitbit user ID as returned by the Fitbit authentication procedure
+      externalUserId: "?"
+      oauth2:
+        # -- Fitbit OAuth 2.0 access token as returned by the Fitbit authentication procedure
+        accessToken: "?"
+        # -- Fitbit OAuth 2.0 refresh token as returned by the Fitbit authentication procedure
+        refreshToken: "?"
+        # -- Optional expiry time of the access token. If absent, it will be estimated to one hour
+        # when the source connector starts. When an authentication error occurs, a new access token will
+        # be fetched regardless of the value in this field.
+        expiresAt: 2018-08-06T00:00:00Z


### PR DESCRIPTION
# Problem
Fitbit connector has a way to configure data download for userd fom a yaml file that contains users data. I intend to use this feature for ad hoc data download for topics that failed to be retrieved. However, the users yaml file cannot be configured from the helm chart.

# Solution
This PR will externalize the contents of the users yaml file to the values.yaml file. Also, the users yaml file is only created when needed (the `user_repository_class` is `YamlUserRepository`).