### PR TITLE
fix: use bitnamilegacy image repository

### DIFF
--- a/charts/radar-nifi/Chart.yaml
+++ b/charts/radar-nifi/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: radar-nifi
-version: 2.0.0
+version: 2.0.1
 appVersion: 2.3.0
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/charts/radar-nifi/README.md
+++ b/charts/radar-nifi/README.md
@@ -2,7 +2,7 @@
 
 # radar-nifi
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: 2.3.0](https://img.shields.io/badge/AppVersion-2.3.0-informational?style=flat-square)
 
 Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 

--- a/charts/radar-nifi/charts/zookeeper/README.md
+++ b/charts/radar-nifi/charts/zookeeper/README.md
@@ -44,7 +44,7 @@ Apache ZooKeeper provides a reliable, centralized register of configuration data
 | diagnosticMode.command[0] | string | `"sleep"` |  |
 | diagnosticMode.args[0] | string | `"infinity"` |  |
 | image.registry | string | `"docker.io"` |  |
-| image.repository | string | `"bitnami/zookeeper"` |  |
+| image.repository | string | `"bitnamilegacy/zookeeper"` |  |
 | image.tag | string | `"3.8.0-debian-11-r5"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.pullSecrets | list | `[]` |  |
@@ -175,7 +175,7 @@ Apache ZooKeeper provides a reliable, centralized register of configuration data
 | persistence.dataLogDir.selector | object | `{}` |  |
 | volumePermissions.enabled | bool | `false` |  |
 | volumePermissions.image.registry | string | `"docker.io"` |  |
-| volumePermissions.image.repository | string | `"bitnami/bitnami-shell"` |  |
+| volumePermissions.image.repository | string | `"bitnamilegacy/bitnami-shell"` |  |
 | volumePermissions.image.tag | string | `"11-debian-11-r4"` |  |
 | volumePermissions.image.pullPolicy | string | `"IfNotPresent"` |  |
 | volumePermissions.image.pullSecrets | list | `[]` |  |

--- a/charts/radar-nifi/charts/zookeeper/values.yaml
+++ b/charts/radar-nifi/charts/zookeeper/values.yaml
@@ -74,7 +74,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/zookeeper
+  repository: bitnamilegacy/zookeeper
   tag: 3.8.0-debian-11-r5
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -626,7 +626,7 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
+    repository: bitnamilegacy/bitnami-shell
     tag: 11-debian-11-r4
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/charts/radar-postgresql/Chart.yaml
+++ b/charts/radar-postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: radar-postgresql
-version: 0.1.3
+version: 0.1.4
 appVersion: 11.16.0
 deprecated: true
 description: PostgreSQL (Postgres) is an open source object-relational database known

--- a/charts/radar-postgresql/README.md
+++ b/charts/radar-postgresql/README.md
@@ -4,7 +4,7 @@
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-postgresql)](https://artifacthub.io/packages/helm/radar-base/radar-postgresql)
 > **:exclamation: This Helm Chart is deprecated!**
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 11.16.0](https://img.shields.io/badge/AppVersion-11.16.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 11.16.0](https://img.shields.io/badge/AppVersion-11.16.0-informational?style=flat-square)
 
 PostgreSQL (Postgres) is an open source object-relational database known for reliability and data integrity. ACID-compliant, it supports foreign keys, joins, views, triggers and stored procedures.
 
@@ -29,7 +29,7 @@ PostgreSQL (Postgres) is an open source object-relational database known for rel
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| postgresql.image.repository | string | `"bitnami/postgresql"` |  |
+| postgresql.image.repository | string | `"bitnamilegacy/postgresql"` |  |
 | postgresql.image.tag | string | `"11.16.0"` |  |
 | postgresql.global.postgresql.auth.postgresPassword | string | `""` |  |
 | postgresql.auth.postgresPassword | string | `""` |  |

--- a/charts/radar-postgresql/values.yaml
+++ b/charts/radar-postgresql/values.yaml
@@ -1,6 +1,6 @@
 postgresql:
   image:
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 11.16.0
   global:
     postgresql:


### PR DESCRIPTION
# Problem
Bitnami has moved supported docker images to a paid license.

# Solution
Legacy docker images (as used by RADAR-base) are still available in the bitnamilegacy repo. This PR will update _repository_ values for internal charts to the new repo.

# Note
Repo for external charts will be handled in PR to the RADAR-Kubernetes repo.