### PR TITLE
refactor: allow only single partition for schema-registry topic

### DIFF
--- a/charts/radar-kafka/Chart.yaml
+++ b/charts/radar-kafka/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: 3.9.0
 description: "Apache Kafka for RADAR-base using the Strimzi Operator"
 name: radar-kafka
-version: 0.0.2
+version: 0.0.3
 keywords:
   - kafka
   - queue

--- a/charts/radar-kafka/README.md
+++ b/charts/radar-kafka/README.md
@@ -3,7 +3,7 @@
 # radar-kafka
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-kafka)](https://artifacthub.io/packages/helm/radar-base/radar-kafka)
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
+![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
 
 Apache Kafka for RADAR-base using the Strimzi Operator
 

--- a/charts/radar-kafka/templates/topics-schema-registry.yaml
+++ b/charts/radar-kafka/templates/topics-schema-registry.yaml
@@ -9,7 +9,9 @@ metadata:
   labels:
     strimzi.io/cluster: {{ template "common.names.fullname" . }}
 spec:
-  partitions: {{ $context.partitions }}
+  {{/*  This topics can have only a single partition*/}}
+  {{/*  see: https://stackoverflow.com/questions/74775392/why-schema-registry-internal-topic-schemas-has-only-single-partition*/}}
+  partitions: 1
   replicas: {{ $topicReplicationFactor }}
   config:
     {{- toYaml $context.config | nindent 4 }}

--- a/charts/radar-kafka/values.yaml
+++ b/charts/radar-kafka/values.yaml
@@ -91,7 +91,6 @@ schema-registry:
           - '{{ $.Values.server_name }}'
 
   topic:
-    partitions: 1
     replicationFactor: 3
     config:
       cleanup.policy: compact


### PR DESCRIPTION
The topic created for schema-registry may only have a single partition. This PR removes the ability to change the value to a different value.