### PR TITLE
feat: delete outdated snyk vulnerability issues after scan

### DIFF
--- a/.github/bin/close_gh_issues
+++ b/.github/bin/close_gh_issues
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script is a temporary fix until the vulnerability reporting action is improved and fixed.
+
+REPO="RADAR-base/radar-helm-charts"
+LABEL="${LABEL:?You must define the LABEL env var}"
+BATCH_SIZE="${BATCH_SIZE:-200}"
+
+while :; do
+  ids=$(gh issue list -R "$REPO" -s open -L "$BATCH_SIZE" \
+        --search "-label:\"$LABEL\"" \
+        --json number \
+      | jq -r '.[].number')
+
+  [ -z "$ids" ] && { echo "Done"; break; }
+
+  echo "Closing:" $ids
+  echo "$ids" | xargs -r -n1 -I{} gh issue close -R "$REPO" {}
+  sleep 1
+done

--- a/.github/workflows/scheduled-snyk-docker.yaml
+++ b/.github/workflows/scheduled-snyk-docker.yaml
@@ -116,3 +116,22 @@ jobs:
           category: ${{ matrix.DOCKER_IMAGE_SHORT }}
         env:
           TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # This step is a temporary fix for closing obsolete issues.
+  # It can be removed when using an improved version of the thehyve/report-vulnerability action.
+  close-old-snyk-issues:
+    needs: scan
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Close previous Snyk issues without current run label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL: Snyk-timestamp:${{ github.run_id }}
+        run: .github/bin/close_gh_issues


### PR DESCRIPTION
# Problem
The current thehyve/vulnerability action does not close obsolete issues for discovered software vulnerabilities.

# Solution
This PR adds a job in the GitHub action that removes issues reported in older scans.

# Note
We can remove this script when the thehyve/vulnerability action is improved and fixed (planned in the coming month).