### PR TITLE
fix: kratos and hydra hostnames

### DIFF
--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.1.12"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 1.6.1
+version: 1.6.2
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -3,7 +3,7 @@
 # management-portal
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
-![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.12](https://img.shields.io/badge/AppVersion-2.1.12-informational?style=flat-square)
+![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.12](https://img.shields.io/badge/AppVersion-2.1.12-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 
@@ -103,10 +103,10 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 | catalogue_server | string | `"catalog-server"` | Hostname of the catalogue-server |
 | identity_server.admin_email | string | `"admin@example.com"` | The admin email to link to the admin service account. This account should only be used to set up admin-users |
 | identity_server.server_url | string | `nil` | The publicly accessible server URL for the IDP; needed when deviating from http(s)://server_name/kratos |
-| identity_server.server_admin_url | string | `"http://kratos-admin"` | The admin server URL for the IDP used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides |
+| identity_server.server_admin_url | string | `"http://radar-kratos-admin"` | The admin server URL for the IDP used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides |
 | identity_server.login_url | string | `nil` | The publicly accessible login URL for the IDP; needed when deviating from http(s)://server_name/kratos-ui |
-| authserver.server_url | string | `"http://hydra:4444"` | The publicly accessible server URL for the authserver; needed when deviating from http(s)://server_name/auth |
-| authserver.server_admin_url | string | `"http://hydra:4445"` | The admin server URL for the authserver used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides |
+| authserver.server_url | string | `"http://radar-hydra:4444"` | The publicly accessible server URL for the authserver; needed when deviating from http(s)://server_name/auth |
+| authserver.server_admin_url | string | `"http://radar-hydra:4445"` | The admin server URL for the authserver used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides |
 | authserver.login_url | string | `"http://localhost:4444"` | The publicly accessible login URL for the authserver; needed when deviating from http(s)://server_name/auth/login |
 | managementportal.catalogue_server_enable_auto_import | bool | `false` | set to true, if automatic source-type import from catalogue server should be enabled |
 | managementportal.common_privacy_policy_url | string | `"http://info.thehyve.nl/radar-cns-privacy-policy"` | Override with a publicly resolvable url of the privacy-policy url for your set-up. This can be overridden on a project basis as well. |

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -319,15 +319,15 @@ identity_server:
   # -- The publicly accessible server URL for the IDP; needed when deviating from http(s)://server_name/kratos
   server_url:
   # -- The admin server URL for the IDP used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides
-  server_admin_url: http://kratos-admin
+  server_admin_url: http://radar-kratos-admin
   # -- The publicly accessible login URL for the IDP; needed when deviating from http(s)://server_name/kratos-ui
   login_url:
 
 authserver:
   # -- The publicly accessible server URL for the authserver; needed when deviating from http(s)://server_name/auth
-  server_url: http://hydra:4444
+  server_url: http://radar-hydra:4444
   # -- The admin server URL for the authserver used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides
-  server_admin_url: http://hydra:4445
+  server_admin_url: http://radar-hydra:4445
   # -- The publicly accessible login URL for the authserver; needed when deviating from http(s)://server_name/auth/login
   login_url: http://localhost:4444
 

--- a/charts/radar-rest-sources-backend/Chart.yaml
+++ b/charts/radar-rest-sources-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.11"
 description: A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 name: radar-rest-sources-backend
-version: 1.5.2
+version: 1.5.3
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-backend

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -3,7 +3,7 @@
 # radar-rest-sources-backend
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-rest-sources-backend)](https://artifacthub.io/packages/helm/radar-base/radar-rest-sources-backend)
 
-![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.11](https://img.shields.io/badge/AppVersion-4.4.11-informational?style=flat-square)
+![Version: 1.5.3](https://img.shields.io/badge/Version-1.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.11](https://img.shields.io/badge/AppVersion-4.4.11-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 
@@ -102,8 +102,8 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 | serverName | string | `"localhost"` | Resolvable server name, needed to find the advertised URL and callback URL |
 | managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of the Management Portal |
 | client_secret | string | `"secret"` | OAuth2 client secret of the radar-rest-sources-backend client from Management Portal |
-| public_key_endpoints | list | `["http://hydra-public:4444/.well-known/jwks.json"]` | List of public key endpoints for token verification |
-| auth_url | string | `"http://hydra-public:4444/oauth2/token"` | Auth url for MP client |
+| public_key_endpoints | list | `["http://radar-hydra-public:4444/.well-known/jwks.json"]` | List of public key endpoints for token verification |
+| auth_url | string | `"http://radar-hydra-public:4444/oauth2/token"` | Auth url for MP client |
 | restSourceClients.fitbit.enable | bool | `false` | set to true, if Fitbit client should be used |
 | restSourceClients.fitbit.sourceType | string | `"FitBit"` | Type of the data sources |
 | restSourceClients.fitbit.authorizationEndpoint | string | `"https://www.fitbit.com/oauth2/authorize"` | Authorization endpoint for Fitbit authentication and authorization |

--- a/charts/radar-rest-sources-backend/values.yaml
+++ b/charts/radar-rest-sources-backend/values.yaml
@@ -289,11 +289,11 @@ client_secret: secret
 
 # -- List of public key endpoints for token verification
 public_key_endpoints:
-  - http://hydra-public:4444/.well-known/jwks.json
+  - http://radar-hydra-public:4444/.well-known/jwks.json
   # - https://localhost/managementportal/oauth/token_key
 
 # -- Auth url for MP client
-auth_url: http://hydra-public:4444/oauth2/token
+auth_url: http://radar-hydra-public:4444/oauth2/token
 
 restSourceClients:
   fitbit:

--- a/charts/radar-self-enrolment-ui/Chart.yaml
+++ b/charts/radar-self-enrolment-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.0.1"
 description: A Helm chart for RADAR-base Self Enrolment UI
 name: radar-self-enrolment-ui
-version: 0.3.0
+version: 0.3.1
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-self-enrolment-ui

--- a/charts/radar-self-enrolment-ui/README.md
+++ b/charts/radar-self-enrolment-ui/README.md
@@ -2,7 +2,7 @@
 
 # radar-self-enrolment-ui
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm chart for RADAR-base Self Enrolment UI
 
@@ -76,7 +76,7 @@ A Helm chart for RADAR-base Self Enrolment UI
 | podSecurityContext.runAsGroup | int | `10000` |  |
 | podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | deployment.resources | object | `{}` |  |
-| deployment.extraEnv | list | `[{"name":"HYDRA_ADMIN_URL","value":"http://hydra-admin"}]` | Array of extra envs to be passed to the deployment. Kubernetes format is expected - name: FOO   value: BAR |
+| deployment.extraEnv | list | `[{"name":"HYDRA_ADMIN_URL","value":"http://radar-hydra-admin"}]` | Array of extra envs to be passed to the deployment. Kubernetes format is expected - name: FOO   value: BAR |
 | deployment.extraVolumes | list | `[]` | If you want to mount external volume For example, mount a secret containing Certificate root CA to verify database TLS connection. |
 | deployment.extraVolumeMounts | list | `[]` |  |
 | deployment.nodeSelector | object | `{}` | Node labels for pod assignment. |
@@ -113,8 +113,8 @@ A Helm chart for RADAR-base Self Enrolment UI
 | kratosAdminUrl | string | `"http://kratos-admin:80/admin"` | Set this to ORY Kratos's Admin URL |
 | kratosPublicUrl | string | `"https://localhost/kratos"` | Set this to ORY Kratos's public URL |
 | kratosBrowserUrl | string | `"https://localhost/kratos"` | Set this to ORY Kratos's public URL accessible from the outside world. |
-| hydraAdminUrl | string | `"http://hydra-admin"` | Set this to ORY Hydra's Admin URL |
-| hydraPublicUrl | string | `"http://hydra-public:4444"` | Set this to ORY Hydra's public URL |
+| hydraAdminUrl | string | `"http://radar-hydra-admin"` | Set this to ORY Hydra's Admin URL |
+| hydraPublicUrl | string | `"http://radar-hydra-public:4444"` | Set this to ORY Hydra's public URL |
 | restSourceBackendUrl | string | `"http://radar-rest-sources-backend:8080/rest-sources/backend"` | Set this to the REST source backend service URL |
 | gatewayUrl | string | `"http://radar-gateway:8080"` | Set this to the RADAR Gateway service URL |
 | armtClientId | string | `"aRMT"` | Client ID for ARMT authentication |

--- a/charts/radar-self-enrolment-ui/values.yaml
+++ b/charts/radar-self-enrolment-ui/values.yaml
@@ -138,7 +138,7 @@ deployment:
   #   value: BAR
   extraEnv:
     - name: HYDRA_ADMIN_URL
-      value: http://hydra-admin
+      value: http://radar-hydra-admin
   # -- If you want to mount external volume
   # For example, mount a secret containing Certificate root CA to verify database
   # TLS connection.
@@ -294,10 +294,10 @@ kratosPublicUrl: "https://localhost/kratos"
 kratosBrowserUrl: "https://localhost/kratos"
 
 # -- Set this to ORY Hydra's Admin URL
-hydraAdminUrl: "http://hydra-admin"
+hydraAdminUrl: "http://radar-hydra-admin"
 
 # -- Set this to ORY Hydra's public URL
-hydraPublicUrl: "http://hydra-public:4444"
+hydraPublicUrl: "http://radar-hydra-public:4444"
 
 # -- Set this to the REST source backend service URL
 restSourceBackendUrl: "http://radar-rest-sources-backend:8080/rest-sources/backend"


### PR DESCRIPTION
The default hostnames for kratos and hydra were not correctly updated to the new chart names. This PR corrects the defaults.