### PR TITLE
fix: remove false positive prometheus rule for radar-kafka

### DIFF
--- a/charts/radar-kafka/Chart.yaml
+++ b/charts/radar-kafka/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: 3.9.0
 description: "Apache Kafka for RADAR-base using the Strimzi Operator"
 name: radar-kafka
-version: 0.1.3
+version: 0.1.4
 keywords:
   - kafka
   - queue

--- a/charts/radar-kafka/README.md
+++ b/charts/radar-kafka/README.md
@@ -3,7 +3,7 @@
 # radar-kafka
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-kafka)](https://artifacthub.io/packages/helm/radar-base/radar-kafka)
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
 
 Apache Kafka for RADAR-base using the Strimzi Operator
 

--- a/charts/radar-kafka/templates/prometheus-rules.yaml
+++ b/charts/radar-kafka/templates/prometheus-rules.yaml
@@ -178,16 +178,6 @@ spec:
       annotations:
         summary: 'Kafka Connect Task Failure'
         description: 'One or more tasks have been in failed state for 5 minutes.'
-  - name: bridge
-    rules:
-    - alert: BridgeContainersDown
-      expr: absent(container_last_seen{container=~".+-bridge",pod=~".+-bridge-.+"})
-      for: 3m
-      labels:
-        severity: major
-      annotations:
-        summary: 'All Kafka Bridge containers down or in CrashLookBackOff status'
-        description: 'All Kafka Bridge containers have been down or in CrashLookBackOff status for 3 minutes'
     - alert: AvgProducerLatency
       expr: strimzi_bridge_kafka_producer_request_latency_avg > 10
       for: 10s


### PR DESCRIPTION
Although Kafka bridge is not deployed, the prometheus rule that warns that there a too few bridge pods. This is a know problem on the Internets regarding the Strimzi provided rules. This PR removes this false positive rule.