### PR TITLE
[radar-kafka] feat: configure kafka prometheus podmonitor scape timings

### DIFF
--- a/charts/radar-kafka/Chart.yaml
+++ b/charts/radar-kafka/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 appVersion: 3.9.0
 description: "Apache Kafka for RADAR-base using the Strimzi Operator"
 name: radar-kafka
-version: 0.1.4
+version: 0.2.4
 keywords:
   - kafka
   - queue

--- a/charts/radar-kafka/README.md
+++ b/charts/radar-kafka/README.md
@@ -3,7 +3,7 @@
 # radar-kafka
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-kafka)](https://artifacthub.io/packages/helm/radar-base/radar-kafka)
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
 
 Apache Kafka for RADAR-base using the Strimzi Operator
 
@@ -49,10 +49,11 @@ Consult the [documentation](https://github.com/lsst-sqre/strimzi-registry-operat
 | dev_deployment | bool | `false` | Deploy with minimal replicas, replicationFactor and without PVCs (a.k.a ephemeral mode) |
 | nameOverride | string | `""` | String to partially override radar-kafka.fullname template with a string (will prepend the release name) |
 | fullnameOverride | string | `""` | String to fully override radar-kafka.fullname template with a string |
-| metrics | object | `{"enabled":true,"kafkaExporter":{"enableSaramaLogging":true,"groupRegex":".*","topicRegex":".*"},"prometheusRules":{"consumerGroupLagDelta":20000}}` | Enable metrics to be collected via Prometheus-operator |
+| metrics | object | `{"enabled":true,"kafkaExporter":{"enableSaramaLogging":true,"groupRegex":".*","topicRegex":".*"},"podMonitor":{"interval":"30s","scrapeTimeout":"30s"},"prometheusRules":{"consumerGroupLagDelta":20000}}` | Enable metrics to be collected via Prometheus-operator |
 | metrics.enabled | bool | `true` | Enable monitoring of metrics |
 | metrics.kafkaExporter | object | `{"enableSaramaLogging":true,"groupRegex":".*","topicRegex":".*"}` | Values for Prometheus JMX Exporter attached to Kafka pods ref: https://strimzi.io/docs/operators/latest/deploying#proc-metrics-kafka-deploy-options-str |
 | metrics.kafkaExporter.groupRegex | string | `".*"` | Regex that selects consumer groups for KafkaExporter errors/warnings. |
+| metrics.podMonitor | object | `{"interval":"30s","scrapeTimeout":"30s"}` | Prometheus scrap config for Kafka pods. These settings do not affect scrape of Strimzi operators. |
 | metrics.prometheusRules | object | `{"consumerGroupLagDelta":20000}` | Custom parameters to selected prometheus rules |
 | metrics.prometheusRules.consumerGroupLagDelta | int | `20000` | Threshold of backpressure (number of messages not handled by consumer group) warning for consumer groups. |
 | strimzi-kafka-operator | object | check `values.yaml` | Values for kafka operator ref: https://strimzi.io/docs/operators/latest/deploying#assembly-operators-str |

--- a/charts/radar-kafka/templates/pod-monitors.yaml
+++ b/charts/radar-kafka/templates/pod-monitors.yaml
@@ -45,6 +45,8 @@ spec:
   podMetricsEndpoints:
   - path: /metrics
     port: tcp-prometheus
+    interval: {{ .Values.metrics.podMonitor.interval }}
+    scrapeTimeout: {{ .Values.metrics.podMonitor.scrapeTimeout }}
     relabelings:
     - separator: ;
       regex: __meta_kubernetes_pod_label_(strimzi_io_.+)

--- a/charts/radar-kafka/values.yaml
+++ b/charts/radar-kafka/values.yaml
@@ -22,6 +22,10 @@ metrics:
     # --
     topicRegex: ".*"
     enableSaramaLogging: true
+  # -- Prometheus scrap config for Kafka pods. These settings do not affect scrape of Strimzi operators.
+  podMonitor:
+    interval: 30s
+    scrapeTimeout: 30s
   # -- Custom parameters to selected prometheus rules
   prometheusRules:
     # -- Threshold of backpressure (number of messages not handled by consumer group) warning for consumer groups.


### PR DESCRIPTION
Podmonitor scrape timings default to 10s. This was insufficient in some cases. This PR allows to configure these timings via helm values. 