### PR TITLE
fix(appserver): management portal public key endpoint

### DIFF
--- a/charts/radar-appserver/Chart.yaml
+++ b/charts/radar-appserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 2.4.5
 description: A Helm chart for the backend application of RADAR-base Appserver
 name: radar-appserver
-version: 0.10.1
+version: 0.10.2
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-appserver

--- a/charts/radar-appserver/README.md
+++ b/charts/radar-appserver/README.md
@@ -3,7 +3,7 @@
 # radar-appserver
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-appserver)](https://artifacthub.io/packages/helm/radar-base/radar-appserver)
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.5](https://img.shields.io/badge/AppVersion-2.4.5-informational?style=flat-square)
+![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.4.5](https://img.shields.io/badge/AppVersion-2.4.5-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Appserver
 
@@ -101,7 +101,7 @@ A Helm chart for the backend application of RADAR-base Appserver
 | managementportal_url | string | `"http://management-portal:8080/managementportal"` | URL of the Management Portal |
 | serverName | string | `"localhost"` |  |
 | managementportal_resource_name | string | `"res_AppServer"` | radar_is.yml config for token verification |
-| public_key_endpoints | string | `nil` |  |
+| public_key_endpoints | list | `["http://management-portal:8080/managementportal/oauth/token_key"]` | List of OAuth2 authentication server public key endpoints for token verification |
 | google_application_credentials | string | `""` | Google credentials containing FCM server key, etc. |
 | github_client_token | string | `""` | Github client token which is used for authenticating requests |
 | smtp.enabled | bool | `false` | set to true, if sending of notifications via email should be enabled. |

--- a/charts/radar-appserver/templates/configmap.yaml
+++ b/charts/radar-appserver/templates/configmap.yaml
@@ -19,7 +19,6 @@ data:
 
     # Set of supported public key endpoints for authentication
     publicKeyEndpoints:
-        - {{ printf "%s://%s/managementportal/oauth/token_key" .Values.advertised_protocol .Values.serverName | quote }}
         {{- range .Values.public_key_endpoints }}
         - {{ . | quote }}
         {{ end -}}

--- a/charts/radar-appserver/values.yaml
+++ b/charts/radar-appserver/values.yaml
@@ -248,9 +248,9 @@ serverName: localhost
 
 # -- radar_is.yml config for token verification
 managementportal_resource_name: res_AppServer
+# -- List of OAuth2 authentication server public key endpoints for token verification
 public_key_endpoints:
-  # List of Management Portal instance public key endpoints for token verification
-  # - https://localhost/managementportal/oauth/token_key
+  - http://management-portal:8080/managementportal/oauth/token_key
 
 # -- Google credentials containing FCM server key, etc.
 google_application_credentials: ""


### PR DESCRIPTION
The default public key endpoint for management portal was incorrect for appserver. This PR will correct this to the internal service for MP.