### PR TITLE
feat(management-portal): add new oauth clients

### DIFF
--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.1.13"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 1.6.3
+version: 1.7.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -3,7 +3,7 @@
 # management-portal
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
-![Version: 1.6.3](https://img.shields.io/badge/Version-1.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.13](https://img.shields.io/badge/AppVersion-2.1.13-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.13](https://img.shields.io/badge/AppVersion-2.1.13-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -640,3 +640,65 @@ oauth_clients:
     authorized_grant_types:
       - client_credentials
     access_token_validity: 900
+
+  nifi:
+    enable: false
+    resource_ids:
+      - res_AppServer
+    client_secret: ""
+    scope:
+      - SUBJECT.READ
+      - SUBJECT.CREATE
+      - SUBJECT.UPDATE
+    authorized_grant_types:
+      - client_credentials
+    access_token_validity: 43200
+    refresh_token_validity: 7948800
+
+  protocol_service:
+    enable: false
+    resource_ids:
+      - res_appconfig
+    client_secret: ""
+    scope:
+      - PROJECT.READ
+      - PROJECT.CREATE
+      - PROJECT.UPDATE
+      - SUBJECT.READ
+      - SUBJECT.CREATE
+      - SUBJECT.UPDATE
+    authorized_grant_types:
+      - client_credentials
+    access_token_validity: 43200
+    refresh_token_validity: 7948800
+
+  questionnaire_service:
+    enable: false
+    resource_ids:
+      - res_appconfig
+    client_secret: ""
+    scope:
+      - PROJECT.READ
+      - PROJECT.CREATE
+      - PROJECT.UPDATE
+      - SUBJECT.READ
+      - SUBJECT.CREATE
+      - SUBJECT.UPDATE
+    authorized_grant_types:
+      - client_credentials
+    access_token_validity: 43200
+    refresh_token_validity: 7948800
+
+  public_config_service:
+    enable: false
+    resource_ids:
+      - res_appconfig
+    client_secret: ""
+    scope:
+      - PROJECT.READ
+      - PROJECT.CREATE
+      - PROJECT.UPDATE
+    authorized_grant_types:
+      - client_credentials
+    access_token_validity: 43200
+    refresh_token_validity: 7948800


### PR DESCRIPTION
This PR adds new oauth clients for management-portal:
- nifi: needed for nifi to access app-server
- protocol_service: needed to retrieve protocol data from app-config
- questionnaire_service: needed to retrieve questionnaire data from app-config
- public_config_service: needed to retrieve global config from app-config