### PR TITLE
feat(redis): add init container to set data dir ownership

### DIFF
--- a/charts/radar-redis/Chart.yaml
+++ b/charts/radar-redis/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v8.2.2"
 description: Redis charts for Radar-base
 name: radar-redis
 home: "https://radar-base.org"
-version: 1.1.0
+version: 1.2.0
 maintainers:
   - email: pim@thehyve.nl
     name: Pim van Nierop

--- a/charts/radar-redis/README.md
+++ b/charts/radar-redis/README.md
@@ -3,7 +3,7 @@
 # radar-redis
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-redis)](https://artifacthub.io/packages/helm/radar-base/radar-redis)
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v8.2.2](https://img.shields.io/badge/AppVersion-v8.2.2-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v8.2.2](https://img.shields.io/badge/AppVersion-v8.2.2-informational?style=flat-square)
 
 Redis charts for Radar-base
 
@@ -48,6 +48,7 @@ Redis charts for Radar-base
 | storage.accessModes | list | `["ReadWriteOnce"]` | Access mode for PVC |
 | storage.size | string | `"1Gi"` | Size of PVC |
 | securityContext | object | `{"fsGroup":1000,"runAsUser":1000}` | Security context for redis pods |
+| initContainer | object | `{"command":["sh","-c","chown -R 1000:1000 /data && chmod -R g+rwX /data"],"enabled":false,"image":"busybox:1.36"}` | When encountering fs permission errors, you can use this initContainer to change the ownership of the data directory. |
 | redisExporter.image.registry | string | `"quay.io"` |  |
 | redisExporter.image.repository | string | `"opstree/redis-exporter"` |  |
 | redisExporter.image.tag | string | `"v1.44.0"` |  |

--- a/charts/radar-redis/templates/redis.yaml
+++ b/charts/radar-redis/templates/redis.yaml
@@ -41,6 +41,9 @@ spec:
         resources:
           requests:
             storage: {{ .Values.storage.size }}
+  {{- if .Values.initContainer.enabled }}
+  initContainer: {{ .Values.initContainer | toYaml | nindent 4 }}
+  {{- end }}
   redisExporter:
     enabled: {{ .Values.metrics.enabled }}
     image: {{ include "common.images.image" (dict "imageRoot" .Values.redisExporter.image "global" .Values.global "chart" .Chart ) }}

--- a/charts/radar-redis/values.yaml
+++ b/charts/radar-redis/values.yaml
@@ -68,6 +68,13 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+# -- When encountering fs permission errors, you can use this initContainer to
+# change the ownership of the data directory.
+initContainer:
+  enabled: false
+  image: busybox:1.36
+  command: ["sh", "-c", "chown -R 1000:1000 /data && chmod -R g+rwX /data"]
+
 redisExporter:
   image:
     registry: quay.io


### PR DESCRIPTION

On certain systems file system permission errors were encountered. This PR will fix that by adding an init container that set the correct file access rules on the /data directory.