### PR TITLE
chore(postgresql): backups off by default

### DIFF
--- a/charts/radar-cloudnative-postgresql/Chart.yaml
+++ b/charts/radar-cloudnative-postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: radar-cloudnative-postgresql
-version: 0.4.0
+version: 0.4.1
 description: CloudNativePG Postgresql helm chart for RADAR-base
 home: https://radar-base.org
 icon: http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png

--- a/charts/radar-cloudnative-postgresql/README.md
+++ b/charts/radar-cloudnative-postgresql/README.md
@@ -3,7 +3,7 @@
 # radar-cloudnative-postgresql
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-cloudnative-postgresql)](https://artifacthub.io/packages/helm/radar-base/radar-cloudnative-postgresql)
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square)
 
 CloudNativePG Postgresql helm chart for RADAR-base
 

--- a/charts/radar-cloudnative-postgresql/values.yaml
+++ b/charts/radar-cloudnative-postgresql/values.yaml
@@ -149,7 +149,7 @@ cluster:
           name: radar-cloudnative-postgresql-uploadconnector
 
   backups:
-    enabled: true
+    enabled: false
     endpointURL: http://minio:9000
     provider: s3
     s3:


### PR DESCRIPTION
I decided to turn the new feature of WAL file backups to object storage off by default. It requires too much analysis and problem solving to be a dafault feature.