### PR TITLE
feat/add HPA support to radar-output

### DIFF
--- a/charts/radar-output/Chart.yaml
+++ b/charts/radar-output/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.0.5"
 description: A Helm chart for RADAR-base output restructure service. This application reads data from intermediate storage and restructure the data into project-> subject-id-> data topic -> data split per hour. This service offers few options to choose the source and target of the pipeline.
 name: radar-output
-version: 1.2.7
+version: 1.2.8
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-output

--- a/charts/radar-output/README.md
+++ b/charts/radar-output/README.md
@@ -3,7 +3,7 @@
 # radar-output
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-output)](https://artifacthub.io/packages/helm/radar-base/radar-output)
 
-![Version: 1.2.7](https://img.shields.io/badge/Version-1.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.5](https://img.shields.io/badge/AppVersion-3.0.5-informational?style=flat-square)
+![Version: 1.2.8](https://img.shields.io/badge/Version-1.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.5](https://img.shields.io/badge/AppVersion-3.0.5-informational?style=flat-square)
 
 A Helm chart for RADAR-base output restructure service. This application reads data from intermediate storage and restructure the data into project-> subject-id-> data topic -> data split per hour. This service offers few options to choose the source and target of the pipeline.
 
@@ -113,6 +113,9 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 | topics.questionnaire_response.pathProperties.plugins | string | `"fixed value"` | Alternative path plugins of the questionnaire_response topic |
 | deduplication.enable | bool | `true` | Whether to enable deduplication |
 | compression.type | string | `"gzip"` | Compression type to use for output files. Can be one of: gzip, zip, none |
+| hpa.enabled | bool | `false` | Enable HPA |
+| hpa.maxReplicas | int | `5` | Maximum number of replicas |
+| hpa.targetCPU | int | `80` | Target CPU utilization percentage |
 
 ## Cost Considerations
 

--- a/charts/radar-output/README.md
+++ b/charts/radar-output/README.md
@@ -107,6 +107,7 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 | paths.input | string | `"topics"` | Relative path to intermediate storage root to browse for data |
 | paths.output | string | `"output"` | Relative path to output storage to write data |
 | paths.factory | string | `"org.radarbase.output.path.FormattedPathFactory"` | Output path construction factory |
+| paths.path.format | string | `"${projectId}/${userId}/${topic}/${filename}"` | Output path format |
 | paths.properties | object | `{}` | Additional properties. For details see https://github.com/RADAR-base/radar-output-restructure/blob/master/restructure.yml |
 | topics | object | `{"questionnaire_response":{"pathProperties":{"format":"${projectId}/${userId}/${topic}/${value:name}/${filename}","plugins":"fixed value"}}}` | Individual topic configuration |
 | topics.questionnaire_response.pathProperties.format | string | `"${projectId}/${userId}/${topic}/${value:name}/${filename}"` | Alternative path output of the questionnaire_response topic |

--- a/charts/radar-output/README.md
+++ b/charts/radar-output/README.md
@@ -35,7 +35,7 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| replicaCount | int | `2` | Number of radar-output replicas to deploy |
+| replicaCount | int | `1` | Number of radar-output replicas to deploy |
 | image.registry | string | `"ghcr.io"` | Image registry |
 | image.repository | string | `"radar-base/radar-output-restructure/radar-output-restructure"` | Image repository |
 | image.tag | string | `nil` | Image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |

--- a/charts/radar-output/README.md
+++ b/charts/radar-output/README.md
@@ -35,7 +35,7 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| replicaCount | int | `1` | Number of radar-output replicas to deploy |
+| replicaCount | int | `2` | Number of radar-output replicas to deploy |
 | image.registry | string | `"ghcr.io"` | Image registry |
 | image.repository | string | `"radar-base/radar-output-restructure/radar-output-restructure"` | Image repository |
 | image.tag | string | `nil` | Image tag (immutable tags are recommended) Overrides the image tag whose default is the chart appVersion. |

--- a/charts/radar-output/README.md
+++ b/charts/radar-output/README.md
@@ -116,6 +116,7 @@ A Helm chart for RADAR-base output restructure service. This application reads d
 | hpa.enabled | bool | `false` | Enable HPA |
 | hpa.maxReplicas | int | `5` | Maximum number of replicas |
 | hpa.targetCPU | int | `80` | Target CPU utilization percentage |
+| hpa.targetMemory | string | `nil` | Target Memory utilization percentage |
 
 ## Cost Considerations
 

--- a/charts/radar-output/templates/configmap.yaml
+++ b/charts/radar-output/templates/configmap.yaml
@@ -140,9 +140,22 @@ data:
       output: "{{ .Values.paths.output }}"
       # Output path construction factory
       factory: {{ .Values.paths.factory }}
-      # Additional properties
+
+      # Global path formatter config (FormattedPathFactory)
+      path:
+        format: {{ .Values.paths.path.format | quote }}
+        {{- if .Values.paths.path.plugins }}
+        plugins: {{ .Values.paths.path.plugins | quote }}
+        {{- end }}
+        {{- if .Values.paths.path.properties }}
+        properties:
+{{ toYaml .Values.paths.path.properties | indent 10 }}
+        {{- end }}
+      # Optional: legacy/general plugin properties merged into path.properties by the app
+      {{- if .Values.paths.properties }}
       properties:
-        {{ .Values.paths.properties | toYaml | indent 8 | trim }}
+{{ toYaml .Values.paths.properties | indent 8 }}
+      {{- end }}
 
     # Individual topic configuration
     {{- if .Values.topics }}

--- a/charts/radar-output/templates/hpa.yaml
+++ b/charts/radar-output/templates/hpa.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "radar-output.fullname" . }}
+  minReplicas: {{ .Values.replicaCount }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.hpa.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPU }}
+    {{- end }}
+    {{- if .Values.hpa.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemory }}
+    {{- end }}
+{{- end }}

--- a/charts/radar-output/values.yaml
+++ b/charts/radar-output/values.yaml
@@ -270,3 +270,12 @@ deduplication:
 compression:
   # -- Compression type to use for output files. Can be one of: gzip, zip, none
   type: gzip
+
+# Horizontal Pod Autoscaler
+hpa:
+  # -- Enable HPA
+  enabled: false
+  # -- Maximum number of replicas
+  maxReplicas: 5
+  # -- Target CPU utilization percentage
+  targetCPU: 80

--- a/charts/radar-output/values.yaml
+++ b/charts/radar-output/values.yaml
@@ -279,3 +279,5 @@ hpa:
   maxReplicas: 5
   # -- Target CPU utilization percentage
   targetCPU: 80
+  # -- Target Memory utilization percentage
+  targetMemory: ~

--- a/charts/radar-output/values.yaml
+++ b/charts/radar-output/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 # -- Number of radar-output replicas to deploy
-replicaCount: 2
+replicaCount: 1
 
 image:
   # -- Image registry

--- a/charts/radar-output/values.yaml
+++ b/charts/radar-output/values.yaml
@@ -238,6 +238,11 @@ paths:
   output: output
   # -- Output path construction factory
   factory: org.radarbase.output.path.FormattedPathFactory
+  path:
+    # -- Output path format
+    format: ${projectId}/${userId}/${topic}/${filename}
+    # -- Output path plugins
+    # plugins: fixed time key value
   # -- Additional properties. For details see https://github.com/RADAR-base/radar-output-restructure/blob/master/restructure.yml
   properties: {}
 

--- a/charts/radar-output/values.yaml
+++ b/charts/radar-output/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 # -- Number of radar-output replicas to deploy
-replicaCount: 1
+replicaCount: 2
 
 image:
   # -- Image registry


### PR DESCRIPTION
- Adds HPA support for radar-output chart with a new hpa.yaml template. Disabled by default (hpa.enabled: false), sysadmins can enable it when needed.
- Also fixes path format config to allow specifying format of restructured files according to: https://github.com/RADAR-base/radar-output-restructure/blob/main/src/main/java/org/radarbase/output/config/PathConfig.kt#L20
