### PR TITLE
[radar-nifi]: Added init container to download jdbc drivers and dbcp service

### DIFF
--- a/charts/radar-nifi/Chart.yaml
+++ b/charts/radar-nifi/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.0.0
+version: 3.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/radar-nifi/README.md
+++ b/charts/radar-nifi/README.md
@@ -2,7 +2,7 @@
 
 # radar-nifi
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -56,6 +56,20 @@ A Helm chart for Kubernetes
 | nifi-cluster.cluster.listenersConfig.sslSecrets.tlsSecretName | string | `"radar-nifi-tls"` |  |
 | nifi-cluster.cluster.listenersConfig.sslSecrets.create | bool | `true` |  |
 | nifi-cluster.cluster.nifiClusterTaskSpec.retryDurationMinutes | int | `10` |  |
+| nifi-cluster.cluster.initContainers[0].name | string | `"download-postgres-driver"` |  |
+| nifi-cluster.cluster.initContainers[0].image | string | `"curlimages/curl:8.12.1"` |  |
+| nifi-cluster.cluster.initContainers[0].command[0] | string | `"sh"` |  |
+| nifi-cluster.cluster.initContainers[0].command[1] | string | `"-c"` |  |
+| nifi-cluster.cluster.initContainers[0].command[2] | string | `"curl -L -o /jdbc/postgresql-42.7.5.jar \\\n  https://jdbc.postgresql.org/download/postgresql-42.7.5.jar\n"` |  |
+| nifi-cluster.cluster.initContainers[0].volumeMounts[0].name | string | `"jdbc-drivers"` |  |
+| nifi-cluster.cluster.initContainers[0].volumeMounts[0].mountPath | string | `"/jdbc"` |  |
+| nifi-cluster.cluster.initContainers[1].name | string | `"download-postgres-nar"` |  |
+| nifi-cluster.cluster.initContainers[1].image | string | `"curlimages/curl:8.12.1"` |  |
+| nifi-cluster.cluster.initContainers[1].command[0] | string | `"sh"` |  |
+| nifi-cluster.cluster.initContainers[1].command[1] | string | `"-c"` |  |
+| nifi-cluster.cluster.initContainers[1].command[2] | string | `"curl -L -o /extensions/nifi-dbcp-service-nar-2.5.0.nar \\\n  https://repo1.maven.org/maven2/org/apache/nifi/nifi-dbcp-service-nar/2.5.0/nifi-dbcp-service-nar-2.5.0.nar\n"` |  |
+| nifi-cluster.cluster.initContainers[1].volumeMounts[0].name | string | `"extensions"` |  |
+| nifi-cluster.cluster.initContainers[1].volumeMounts[0].mountPath | string | `"/extensions"` |  |
 | nifi-cluster.cluster.nodeConfigGroups.default_group.fsGroup | int | `1337` |  |
 | nifi-cluster.cluster.nodeConfigGroups.default_group.isNode | bool | `true` |  |
 | nifi-cluster.cluster.nodeConfigGroups.default_group.resourcesRequirements.limits.cpu | int | `2` |  |
@@ -83,6 +97,12 @@ A Helm chart for Kubernetes
 | nifi-cluster.cluster.nodeConfigGroups.default_group.storageConfigs[4].name | string | `"data"` |  |
 | nifi-cluster.cluster.nodeConfigGroups.default_group.storageConfigs[4].pvcSpec.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | nifi-cluster.cluster.nodeConfigGroups.default_group.storageConfigs[4].pvcSpec.resources.requests.storage | string | `"5Gi"` |  |
+| nifi-cluster.cluster.nodeConfigGroups.default_group.externalVolumeConfigs[0].name | string | `"jdbc-drivers"` |  |
+| nifi-cluster.cluster.nodeConfigGroups.default_group.externalVolumeConfigs[0].mountPath | string | `"/opt/nifi/jdbc"` |  |
+| nifi-cluster.cluster.nodeConfigGroups.default_group.externalVolumeConfigs[0].emptyDir | object | `{}` |  |
+| nifi-cluster.cluster.nodeConfigGroups.default_group.externalVolumeConfigs[1].name | string | `"extensions"` |  |
+| nifi-cluster.cluster.nodeConfigGroups.default_group.externalVolumeConfigs[1].mountPath | string | `"/opt/nifi/extensions"` |  |
+| nifi-cluster.cluster.nodeConfigGroups.default_group.externalVolumeConfigs[1].emptyDir | object | `{}` |  |
 | nifi-cluster.cluster.nodes[0].id | int | `0` |  |
 | nifi-cluster.cluster.nodes[0].labels.nifi_node_group | string | `"default_group"` |  |
 | nifi-cluster.cluster.nodes[0].nodeConfigGroup | string | `"default_group"` |  |

--- a/charts/radar-nifi/values.yaml
+++ b/charts/radar-nifi/values.yaml
@@ -86,6 +86,29 @@ nifi-cluster:
         create: true
     nifiClusterTaskSpec:
       retryDurationMinutes: 10
+    initContainers:
+      - name: download-postgres-driver
+        image: curlimages/curl:8.12.1
+        command:
+          - sh
+          - -c
+          - |
+            curl -L -o /jdbc/postgresql-42.7.5.jar \
+              https://jdbc.postgresql.org/download/postgresql-42.7.5.jar
+        volumeMounts:
+          - name: jdbc-drivers
+            mountPath: /jdbc
+      - name: download-postgres-nar
+        image: curlimages/curl:8.12.1
+        command:
+          - sh
+          - -c
+          - |
+            curl -L -o /extensions/nifi-dbcp-service-nar-2.5.0.nar \
+              https://repo1.maven.org/maven2/org/apache/nifi/nifi-dbcp-service-nar/2.5.0/nifi-dbcp-service-nar-2.5.0.nar
+        volumeMounts:
+          - name: extensions
+            mountPath: /extensions
     nodeConfigGroups:
       default_group:
         fsGroup: 1337
@@ -141,6 +164,13 @@ nifi-cluster:
               resources:
                 requests:
                   storage: 5Gi
+        externalVolumeConfigs:
+          - name: jdbc-drivers
+            mountPath: /opt/nifi/jdbc
+            emptyDir: {}
+          - name: extensions
+            mountPath: /opt/nifi/extensions
+            emptyDir: {}
     nodes:
       - id: 0
         labels:


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of maintainers might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Added init container to download jdbc drivers and dbcp service


**Benefits**

Now we could connect and do operations in timescaledb and postgres directly from NiFi. 


**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
