### PR TITLE
Add Garmin OAuth2 config support for rest-sources-backend and push-en…

### DIFF
--- a/charts/radar-push-endpoint/README.md
+++ b/charts/radar-push-endpoint/README.md
@@ -113,6 +113,7 @@ A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming d
 | cc.schemaRegistryApiKey | string | `"srApiKey"` | Confluent Cloud schema registry API key |
 | cc.schemaRegistryApiSecret | string | `"srApiSecret"` | Confluent Cloud schema registry API secret |
 | garmin.enabled | bool | `true` | Whether to enable Garmin endpoints |
+| garmin.oauthVersion | string | `"oauth2"` | OAuth version to use: "oauth2" for PKCE flow, "oauth1" for legacy flow |
 | garmin.consumerKey | string | `"consumerKey"` | Consumer key for you application in Garmin Health API developer portal |
 | garmin.consumerSecret | string | `"consumerSecret"` | Consumer secret for you application in Garmin Health API developer portal |
 | garmin.userRepositoryClass | string | `"org.radarbase.push.integration.garmin.user.GarminServiceUserRepository"` | The user repository to use for getting list of users and their authorization information |

--- a/charts/radar-push-endpoint/templates/configmap.yaml
+++ b/charts/radar-push-endpoint/templates/configmap.yaml
@@ -57,6 +57,7 @@ data:
     pushIntegration:
       garmin:
         enabled: {{ .Values.garmin.enabled }}
+        oauthVersion: {{ .Values.garmin.oauthVersion }}
         consumerKey: {{ .Values.garmin.consumerKey }}
         consumerSecret: {{ .Values.garmin.consumerSecret }}
         userRepositoryClass: {{ .Values.garmin.userRepositoryClass }}

--- a/charts/radar-push-endpoint/values.yaml
+++ b/charts/radar-push-endpoint/values.yaml
@@ -315,6 +315,8 @@ cc:
 garmin:
   # -- Whether to enable Garmin endpoints
   enabled: true
+  # -- OAuth version to use: "oauth2" for PKCE flow, "oauth1" for legacy flow
+  oauthVersion: "oauth2"
   # -- Consumer key for you application in Garmin Health API developer portal
   consumerKey: "consumerKey"
   # -- Consumer secret for you application in Garmin Health API developer portal

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -111,15 +111,19 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 | restSourceClients.fitbit.clientId | string | `nil` | FitBit client id |
 | restSourceClients.fitbit.clientSecret | string | `nil` | FitBit client secret |
 | restSourceClients.fitbit.scope | string | `"activity heartrate sleep profile"` | List of scopes of the data that should be collected from Fitbit. For details, please refer to https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/#Scopes |
+| restSourceClients.fitbit.usesPkce | bool | `false` | Whether this client uses PKCE for authorization |
+| restSourceClients.fitbit.oauthVersion | string | `"oauth2"` | OAuth version to use: "oauth2" for standard OAuth2 flow |
 | restSourceClients.garmin.enable | bool | `false` | set to true, if Garmin client should be used |
 | restSourceClients.garmin.sourceType | string | `"Garmin"` | Type of the data sources |
-| restSourceClients.garmin.preAuthorizationEndpoint | string | `"https://connectapi.garmin.com/oauth-service/oauth/request_token"` | Pre authorization endpoint to get request token in OAuth 1.0 terminology |
-| restSourceClients.garmin.authorizationEndpoint | string | `"https://connect.garmin.com/oauthConfirm"` | Authorization endpoint to get oauth confirmation in OAuth 1.0 terminology |
-| restSourceClients.garmin.deregistrationEndpoint | string | `"https://healthapi.garmin.com/wellness-api/rest/user/registration"` | Endpoint to deregister a user on garmin to disable receiving push requests |
-| restSourceClients.garmin.tokenEndpoint | string | `"https://connectapi.garmin.com/oauth-service/oauth/access_token"` | Token endpoint to request access-token from Garmin |
+| restSourceClients.garmin.oauthVersion | string | `"oauth2"` | OAuth version to use: "oauth2" for PKCE flow, "oauth1" for legacy flow. OAuth1 will be retired on 12/31/2026. |
+| restSourceClients.garmin.usesPkce | bool | `true` | Whether this client uses PKCE (must be true for Garmin OAuth2) |
+| restSourceClients.garmin.preAuthorizationEndpoint | string | `"https://connectapi.garmin.com/oauth-service/oauth/request_token"` | Pre authorization endpoint to get request token (OAuth1 only, ignored when oauthVersion is oauth2) |
+| restSourceClients.garmin.authorizationEndpoint | string | `"https://connect.garmin.com/oauth2Confirm"` | Authorization endpoint for Garmin authentication. For OAuth2: oauth2Confirm, for OAuth1: oauthConfirm |
+| restSourceClients.garmin.tokenEndpoint | string | `"https://diauth.garmin.com/di-oauth2-service/oauth/token"` | Token endpoint to request access-token from Garmin. For OAuth2: di-oauth2-service, for OAuth1: oauth-service |
+| restSourceClients.garmin.deregistrationEndpoint | string | `"https://apis.garmin.com/wellness-api/rest/user/registration"` | Endpoint to deregister a user on Garmin to disable receiving push requests |
 | restSourceClients.garmin.clientId | string | `"Garmin-clientid"` | Garmin client id |
 | restSourceClients.garmin.clientSecret | string | `"Garmin-clientsecret"` | Garmin client secret |
-| restSourceClients.garmin.scope | string | `"activity heartrate sleep profile"` | List of scopes of the data that should be collected from Garmin. |
+| restSourceClients.garmin.scope | string | `"activity heartrate sleep profile"` | Scopes for OAuth1 flow (not used in OAuth2 - Garmin manages scopes server-side for OAuth2) |
 | restSourceClients.oura.enable | bool | `true` | set to true, if Oura client should be used |
 | restSourceClients.oura.sourceType | string | `"Oura"` | Type of the data sources |
 | restSourceClients.oura.authorizationEndpoint | string | `"https://cloud.ouraring.com/oauth/authorize"` | Authorization endpoint for Oura authentication and authorization |
@@ -128,3 +132,5 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 | restSourceClients.oura.clientId | string | `"Oura-clientid"` | Oura client id |
 | restSourceClients.oura.clientSecret | string | `"Oura-clientsecret"` | Oura client secret |
 | restSourceClients.oura.scope | string | `"daily session heartrate workout tag personal email spo2 ring_configuration"` | List of scopes of the data that should be collected from Oura. For details, please refer to https://cloud.ouraring.com/docs/authentication |
+| restSourceClients.oura.usesPkce | bool | `true` | Whether this client uses PKCE for authorization |
+| restSourceClients.oura.oauthVersion | string | `"oauth2"` | OAuth version to use: "oauth2" for standard OAuth2 flow |

--- a/charts/radar-rest-sources-backend/values.yaml
+++ b/charts/radar-rest-sources-backend/values.yaml
@@ -311,25 +311,33 @@ restSourceClients:
     clientSecret:
     # -- List of scopes of the data that should be collected from Fitbit. For details, please refer to https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/#Scopes
     scope: activity heartrate sleep profile
+    # -- Whether this client uses PKCE for authorization
+    usesPkce: false
+    # -- OAuth version to use: "oauth2" for standard OAuth2 flow
+    oauthVersion: oauth2
 
   garmin:
     # -- set to true, if Garmin client should be used
     enable: false
     # -- Type of the data sources
     sourceType: Garmin
-    # -- Pre authorization endpoint to get request token in OAuth 1.0 terminology
+    # -- OAuth version to use: "oauth2" for PKCE flow, "oauth1" for legacy flow. OAuth1 will be retired on 12/31/2026.
+    oauthVersion: oauth2
+    # -- Whether this client uses PKCE (must be true for Garmin OAuth2)
+    usesPkce: true
+    # -- Pre authorization endpoint to get request token (OAuth1 only, ignored when oauthVersion is oauth2)
     preAuthorizationEndpoint: https://connectapi.garmin.com/oauth-service/oauth/request_token
-    # -- Authorization endpoint to get oauth confirmation in OAuth 1.0 terminology
-    authorizationEndpoint: https://connect.garmin.com/oauthConfirm
-    # -- Endpoint to deregister a user on garmin to disable receiving push requests
-    deregistrationEndpoint: https://healthapi.garmin.com/wellness-api/rest/user/registration
-     # -- Token endpoint to request access-token from Garmin
-    tokenEndpoint: https://connectapi.garmin.com/oauth-service/oauth/access_token
+    # -- Authorization endpoint for Garmin authentication. For OAuth2: oauth2Confirm, for OAuth1: oauthConfirm
+    authorizationEndpoint: https://connect.garmin.com/oauth2Confirm
+    # -- Token endpoint to request access-token from Garmin. For OAuth2: di-oauth2-service, for OAuth1: oauth-service
+    tokenEndpoint: https://diauth.garmin.com/di-oauth2-service/oauth/token
+    # -- Endpoint to deregister a user on Garmin to disable receiving push requests
+    deregistrationEndpoint: https://apis.garmin.com/wellness-api/rest/user/registration
     # -- Garmin client id
     clientId: Garmin-clientid
     # -- Garmin client secret
     clientSecret: Garmin-clientsecret
-    # -- List of scopes of the data that should be collected from Garmin.
+    # -- Scopes for OAuth1 flow (not used in OAuth2 - Garmin manages scopes server-side for OAuth2)
     scope: activity heartrate sleep profile
 
   oura:
@@ -348,3 +356,7 @@ restSourceClients:
     clientSecret: Oura-clientsecret
     # -- List of scopes of the data that should be collected from Oura. For details, please refer to https://cloud.ouraring.com/docs/authentication
     scope: daily session heartrate workout tag personal email spo2 ring_configuration
+    # -- Whether this client uses PKCE for authorization
+    usesPkce: true
+    # -- OAuth version to use: "oauth2" for standard OAuth2 flow
+    oauthVersion: oauth2


### PR DESCRIPTION
Garmin is migrating from OAuth1 to OAuth2 PKCE. These Helm chart changes align with the application-level changes in radar-rest-source-auth-backend and radar-push-endpoint that add dual oauth support:

- Updated `radar-rest-sources-backend` Garmin values with OAuth2 PKCE endpoints (`oauth2Confirm`, `di-oauth2-service`) while retaining OAuth1 endpoints for backward compatibility until OAuth1 retirement (12/31/2026)
- Added `oauthVersion` and `usesPkce` fields to Garmin config in `radar-rest-sources-backend` to support runtime selection between OAuth1 and OAuth2
- Added `oauthVersion` config to `radar-push-endpoint` values and ConfigMap template to enable OAuth2 auth validation for Garmin push notifications

