### PR TITLE
Fix JDBC connector version handling

### DIFF
--- a/charts/radar-jdbc-connector/Chart.yaml
+++ b/charts/radar-jdbc-connector/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: 10.8.2
+appVersion: 10.8.2-radar
 name: radar-jdbc-connector
 description: A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
-version: 0.11.1
+version: 0.11.2
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-jdbc-connector

--- a/charts/radar-jdbc-connector/README.md
+++ b/charts/radar-jdbc-connector/README.md
@@ -3,7 +3,7 @@
 # radar-jdbc-connector
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-jdbc-connector)](https://artifacthub.io/packages/helm/radar-base/radar-jdbc-connector)
 
-![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.8.2](https://img.shields.io/badge/AppVersion-10.8.2-informational?style=flat-square)
+![Version: 0.11.2](https://img.shields.io/badge/Version-0.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.8.2-radar](https://img.shields.io/badge/AppVersion-10.8.2--radar-informational?style=flat-square)
 
 A Helm chart for RADAR-base JDBC Kafka connector. This is a fork of the Kafka JDBC connector which allows data from topics to be imported into JDBC databases (including TimescaleDB databases which is used in the dashboard pipeline).
 


### PR DESCRIPTION
This PR corrects the docker image tag for JDBC connector helm chart (versioning/tags clash with the jdbc-connector upstream repo and are assigned a '-radar' suffix).