### PR TITLE
[management-portal] Latest ory update

### DIFF
--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.1.13"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
-version: 1.6.3
+version: 1.7.0
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/management-portal

--- a/charts/management-portal/Chart.yaml
+++ b/charts/management-portal/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.1.13"
+appVersion: "3.0.0"
 description: A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 name: management-portal
 version: 1.7.0

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -3,7 +3,7 @@
 # management-portal
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
-![Version: 1.6.3](https://img.shields.io/badge/Version-1.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.13](https://img.shields.io/badge/AppVersion-2.1.13-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.13](https://img.shields.io/badge/AppVersion-2.1.13-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 
@@ -91,23 +91,27 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 | postgres.host | string | `nil` | host name of the postgres db |
 | postgres.port | string | `nil` | post of the postgres db |
 | postgres.database | string | `nil` | database name |
-| postgres.urlSecret | object | `{"key":"jdbc-uri","name":"radar-cloudnative-postgresql-managementportal"}` | Kubernetes secret containing the database JDBC Connection url (disables use of 'host', 'port' and 'database' values). |
+| postgres.urlSecret | object | `{"key":"jdbc-uri","name":null}` | Kubernetes secret containing the database JDBC Connection url (disables use of 'host', 'port' and 'database' values). Set to empty/null to use chart's own secret created from postgres.url value Otherwise e.g. name: radar-cloudnative-postgresql-managementportal |
 | postgres.user | string | `nil` | database user |
-| postgres.userSecret | object | `{"key":"username","name":"radar-cloudnative-postgresql-managementportal"}` | Kubernetes secret containing the database username (disables use of 'user' value). |
+| postgres.userSecret | object | `{"key":"username","name":null}` | Kubernetes secret containing the database username (disables use of 'user' value). Set to empty/null to use chart's own secret created from postgres.user value Otherwise e.g. name: radar-cloudnative-postgresql-managementportal |
 | postgres.password | string | `nil` | password of the database user |
-| postgres.passwordSecret | object | `{"key":"password","name":"radar-cloudnative-postgresql-managementportal"}` | Kubernetes secret containing the database password (disables use of 'password' value). |
+| postgres.passwordSecret | object | `{"key":"password","name":null}` | Kubernetes secret containing the database password (disables use of 'password' value). Set to empty/null to use chart's own secret created from postgres.password value Otherwise e.g. name: radar-cloudnative-postgresql-managementportal |
 | postgres.connection_parameters | string | `""` | Additional JDBC connection parameters e.g. sslmode=verify-full. Ignored when using 'urlSecret'. |
 | postgres.ssl.enabled | bool | `false` | set to true if the connecting to postgres using SSL |
 | postgres.ssl.keystore | string | `""` | base64 encoded certificate needed to connect to the PostgreSQL With helmfile, this can be set in a production.yaml.gotmpl file by setting   keystore: {{ readFile "certificate.pem" | b64enc | quote }} or with SOPS   keystore: {{ exec "sops" (list "-d" "certificate.pem") | b64enc | quote }} |
 | server_name | string | `"localhost"` | domain name of the server |
 | catalogue_server | string | `"catalog-server"` | Hostname of the catalogue-server |
+| identity_server.internal | bool | `true` | Whether the IDP is the MP's internal IDP |
+| identity_server.public_url | string | `"http://radar-kratos-public"` | The publicly accessible server URL for the IDP; needed when deviating from http(s)://server_name/kratos |
+| identity_server.admin_url | string | `"http://radar-kratos-admin"` | The admin server URL for the IDP used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides |
+| identity_server.user_activation_flow_type | string | `"verification"` | The user activation flow type to use for Management Portal (e.g., recovery, verification) |
+| identity_server.user_activation_method | string | `"link"` | The user activation method to use for Management Portal (e.g., link, code) |
 | identity_server.admin_email | string | `"admin@example.com"` | The admin email to link to the admin service account. This account should only be used to set up admin-users |
-| identity_server.server_url | string | `nil` | The publicly accessible server URL for the IDP; needed when deviating from http(s)://server_name/kratos |
-| identity_server.server_admin_url | string | `"http://radar-kratos-admin"` | The admin server URL for the IDP used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides |
-| identity_server.login_url | string | `nil` | The publicly accessible login URL for the IDP; needed when deviating from http(s)://server_name/kratos-ui |
-| authserver.server_url | string | `"http://radar-hydra:4444"` | The publicly accessible server URL for the authserver; needed when deviating from http(s)://server_name/auth |
-| authserver.server_admin_url | string | `"http://radar-hydra:4445"` | The admin server URL for the authserver used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides |
-| authserver.login_url | string | `"http://localhost:4444"` | The publicly accessible login URL for the authserver; needed when deviating from http(s)://server_name/auth/login |
+| authserver.internal | bool | `true` | Whether the authserver is the MP's internal authserver |
+| authserver.token_url | string | `"http://radar-hydra-public:4444/oauth2/token"` | The publicly accessible server URL for the authserver; needed when deviating from http(s)://server_name/auth |
+| authserver.admin_url | string | `"http://radar-hydra-admin:4445"` | The admin server URL for the authserver used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides |
+| authserver.auth_url | string | `"{{ .Values.advertised_protocol }}://{{ .Values.server_name }}/hydra/oauth2/auth"` | The publicly accessible login URL for the authserver; needed when deviating from http(s)://server_name/auth/login |
+| authserver.jwks_url | string | `"http://radar-hydra-admin:4445/admin/keys/hydra.jwt.access-token"` | The JWKS URL for the authserver; needed when deviating from http(s)://server_name/auth/jwks |
 | managementportal.catalogue_server_enable_auto_import | bool | `false` | set to true, if automatic source-type import from catalogue server should be enabled |
 | managementportal.common_privacy_policy_url | string | `"http://info.thehyve.nl/radar-cns-privacy-policy"` | Override with a publicly resolvable url of the privacy-policy url for your set-up. This can be overridden on a project basis as well. |
 | managementportal.oauth_checking_key_aliases_0 | string | `"radarbase-managementportal-ec"` | Keystore alias to sign JWT tokens from Management Portal |
@@ -115,6 +119,8 @@ A Helm chart for RADAR-Base Management Portal to manage projects and participant
 | managementportal.oauth_require_aal2 | bool | `true` | Whether or not to require AAL2 level authentication (i.e. MFA) |
 | managementportal.frontend_client_secret | string | `"xxx"` | OAuth2 Client secret of the Management Portal frontend application |
 | managementportal.common_admin_password | string | `"xxx"` | Admin password of the default admin user created by the system |
+| managementportal.oauth_clients_file | string | `"/secrets/oauth_client_details.csv"` | The file where the OAuth2 client details are stored |
+| managementportal.base_url | string | `""` | Base URL managementportal calls from inside the application container |
 | smtp.enabled | bool | `false` | set to true, if SMTP server should be enabled. Required to be true for production setup |
 | smtp.host | string | `"smtp"` | Hostname of the SMTP server |
 | smtp.port | int | `25` | Port of the SMTP server |

--- a/charts/management-portal/README.md
+++ b/charts/management-portal/README.md
@@ -3,7 +3,7 @@
 # management-portal
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/management-portal)](https://artifacthub.io/packages/helm/radar-base/management-portal)
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.13](https://img.shields.io/badge/AppVersion-2.1.13-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A Helm chart for RADAR-Base Management Portal to manage projects and participants throughout RADAR-base.
 

--- a/charts/management-portal/templates/deployment.yaml
+++ b/charts/management-portal/templates/deployment.yaml
@@ -58,18 +58,33 @@ spec:
           - name: SPRING_DATASOURCE_URL
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.postgres.urlSecret.name | default $secretName }}
-                key: {{ .Values.postgres.urlSecret.key | default "databaseUrl" }}
+{{- if .Values.postgres.urlSecret.name }}
+                name: {{ .Values.postgres.urlSecret.name }}
+                key: {{ .Values.postgres.urlSecret.key | default "jdbc-uri" }}
+{{- else }}
+                name: {{ $secretName }}
+                key: postgres_url
+{{- end }}
           - name: SPRING_DATASOURCE_USERNAME
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.postgres.userSecret.name | default $secretName }}
-                key: {{ .Values.postgres.userSecret.key | default "databaseUser" }}
+{{- if .Values.postgres.userSecret.name }}
+                name: {{ .Values.postgres.userSecret.name }}
+                key: {{ .Values.postgres.userSecret.key | default "username" }}
+{{- else }}
+                name: {{ $secretName }}
+                key: postgresql_user
+{{- end }}
           - name: SPRING_DATASOURCE_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.postgres.passwordSecret.name | default $secretName }}
-                key: {{ .Values.postgres.passwordSecret.key | default "databasePassword" }}
+{{- if .Values.postgres.passwordSecret.name }}
+                name: {{ .Values.postgres.passwordSecret.name }}
+                key: {{ .Values.postgres.passwordSecret.key | default "password" }}
+{{- else }}
+                name: {{ $secretName }}
+                key: postgresql_password
+{{- end }}
           - name: SPRING_DATASOURCE_HIKARI_CONNECTION_TIMEOUT
             value: "15000"
           - name: SPRING_DATASOURCE_HIKARI_VALIDATION_TIMEOUT
@@ -81,34 +96,48 @@ spec:
           - name: MANAGEMENTPORTAL_COMMON_BASEURL
             value: {{ printf "%s://%s" .Values.advertised_protocol .Values.server_name }}
           - name: MANAGEMENTPORTAL_COMMON_MANAGEMENT_PORTAL_BASE_URL
+          {{- if .Values.managementportal.base_url }}
+            value: {{ .Values.managementportal.base_url }}
+          {{- else }}
             value: {{ printf "%s://%s/managementportal" .Values.advertised_protocol .Values.server_name }}
+          {{- end }}
+          - name: MANAGEMENTPORTAL_FRONTEND_CLIENTID
+            value: "ManagementPortalapp"
           - name: MANAGEMENTPORTAL_FRONTEND_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
                 name: {{ $secretName }}
                 key: managementportal_frontend_client_secret
-          - name: MANAGEMENTPORTAL_OAUTH_CLIENTS_FILE
-            value: /secrets/oauth_client_details.csv
           - name: MANAGEMENTPORTAL_CATALOGUE_SERVER_ENABLE_AUTO_IMPORT
             value: "{{ .Values.managementportal.catalogue_server_enable_auto_import }}"
+          - name: MANAGEMENTPORTAL_OAUTH_CLIENTS_FILE
+            value: "{{ .Values.managementportal.oauth_clients_file }}"
           - name: MANAGEMENTPORTAL_OAUTH_REQUIRE_AAL2
             value: "{{ .Values.managementportal.oauth_require_aal2 }}"
           - name: MANAGEMENTPORTAL_CATALOGUE_SERVER_SERVER_URL
             value: http://{{ .Values.catalogue_server }}:9010/source-types
-          - name: MANAGEMENTPORTAL_IDENTITY_SERVER_ADMIN_EMAIL
+          - name: MANAGEMENTPORTAL_IDENTITYSERVER_ADMINEMAIL
             value: {{ .Values.identity_server.admin_email }}
-          - name: MANAGEMENTPORTAL_IDENTITY_SERVER_SERVER_URL
-            value: {{ $idpServerUrl }}
-          - name: MANAGEMENTPORTAL_IDENTITY_SERVER_LOGIN_URL
-            value: {{ $idpLoginUrl }}
-          - name: MANAGEMENTPORTAL_IDENTITY_SERVER_SERVER_ADMIN_URL
-            value: {{ .Values.identity_server.server_admin_url }}
-          - name: MANAGEMENTPORTAL_AUTHSERVER_SERVERURL
-            value:  {{ $idpServerUrl }}
-          - name: MANAGEMENTPORTAL_AUTHSERVER_LOGINURL
-            value: {{ $idpLoginUrl }}
-          - name: MANAGEMENTPORTAL_AUTHSERVER_SERVERADMINURL
-            value: {{ .Values.authserver.server_admin_url | quote }}
+          - name: MANAGEMENTPORTAL_IDENTITYSERVER_PUBLICURL
+            value: {{ tpl .Values.identity_server.public_url . }}
+          - name: MANAGEMENTPORTAL_IDENTITYSERVER_ADMINURL
+            value: {{ tpl .Values.identity_server.admin_url . }}
+          - name: MANAGEMENTPORTAL_IDENTITYSERVER_INTERNAL
+            value: {{ .Values.identity_server.internal | quote }}
+          - name: MANAGEMENTPORTAL_IDENTITYSERVER_USER_ACTIVATION_FLOW_TYPE
+            value: {{ .Values.identity_server.user_activation_flow_type | quote }}
+          - name: MANAGEMENTPORTAL_IDENTITYSERVER_USER_ACTIVATION_METHOD
+            value: {{ .Values.identity_server.user_activation_method | quote }}
+          - name: MANAGEMENTPORTAL_AUTHSERVER_TOKENURL
+            value: {{ tpl .Values.authserver.token_url . }}
+          - name: MANAGEMENTPORTAL_AUTHSERVER_AUTHURL
+            value: {{ tpl .Values.authserver.auth_url . }}
+          - name: MANAGEMENTPORTAL_AUTHSERVER_INTERNAL
+            value: {{ .Values.authserver.internal | quote }}
+          - name: MANAGEMENTPORTAL_AUTHSERVER_ADMINURL
+            value: {{ tpl .Values.authserver.admin_url . }}
+          - name: MANAGEMENTPORTAL_AUTHSERVER_JWKSURL
+            value: {{ tpl .Values.authserver.jwks_url . }}
           - name: MANAGEMENTPORTAL_COMMON_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
@@ -138,14 +167,12 @@ spec:
               secretKeyRef:
                 name: {{ $secretName }}
                 key: smtpPassword
-          {{ end }}
-          - name: SPRING_MAIL_FROM
-            value: {{ .Values.smtp.from | quote }}
+          {{- end }}
           - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_AUTH
             value: "{{ .Values.smtp.auth }}"
           - name: SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE
             value: {{ .Values.smtp.starttls | quote }}
-          {{ end }}
+          {{- end }}
           {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -200,21 +227,26 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /config/
+            {{- if .Values.authserver.internal }}
             - name: secrets-config
               mountPath: /secrets/
+              # Otherwise: Unable to read header from OAuth clients file: java.nio.file.NoSuchFileException: /mp-includes/config/oauth_client_details.csv
+            {{- end }}
             - name: keystore
               mountPath: /mp-includes/config/
             {{- if .Values.postgres.ssl.enabled }}
             - name: postgres-root-cert
               mountPath: /root/.postgresql/
-            {{ end }}
+            {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "management-portal.fullname" . }}
+        {{- if .Values.authserver.internal }}
         - name: secrets-config
           secret:
             secretName: {{ include "management-portal.fullname" . }}-config
+        {{- end }}
         - name: keystore
           secret:
             secretName: {{ include "management-portal.fullname" . }}-keystore
@@ -222,7 +254,7 @@ spec:
         - name: postgres-root-cert
           secret:
             secretName: {{ include "management-portal.fullname" . }}-root-cert
-        {{ end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/management-portal/templates/ingress.yaml
+++ b/charts/management-portal/templates/ingress.yaml
@@ -24,13 +24,13 @@ spec:
   tls:
     - hosts:
       {{- range $hosts }}
-        - {{ . | quote }}
+        - {{ ( tpl . $ ) | quote }}
       {{- end }}
       secretName: {{ .Values.ingress.tls.secretName }}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . | quote }}
+    - host: {{ ( tpl . $ ) | quote }}
       http:
         paths:
           - path: {{ $path | quote }}

--- a/charts/management-portal/templates/secrets-config.yaml
+++ b/charts/management-portal/templates/secrets-config.yaml
@@ -13,9 +13,9 @@ client_id;resource_ids;client_secret;scope;authorized_grant_types;redirect_uri;a
 {{- range $index, $redirect_uri := $client.redirect_uri -}}
   {{- if gt $index 0 -}},{{- end -}}
   {{- if regexMatch "^/" $redirect_uri -}}
-    https://{{ $.Values.server_name }}{{ $redirect_uri }}
+  {{ $.Values.advertised_protocol }}://{{ $.Values.server_name }}{{ $redirect_uri }}
   {{- else -}}
-    {{ $redirect_uri }}
+    {{ tpl $redirect_uri $ }}
 {{- end -}}
 {{- end -}};
 {{- $client.authorities | default "" }};
@@ -26,7 +26,8 @@ client_id;resource_ids;client_secret;scope;authorized_grant_types;redirect_uri;a
 {{- end -}}
 {{- end -}}
 {{- end -}}
-{{- end}}
+{{- end }}
+{{- if .Values.authserver.internal }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -38,3 +39,4 @@ metadata:
   {{- end }}
 data:
   oauth_client_details.csv: {{ include "oauth-clients-details.csv" . | b64enc | quote }}
+{{- end }}

--- a/charts/management-portal/templates/secrets.yaml
+++ b/charts/management-portal/templates/secrets.yaml
@@ -9,17 +9,24 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if and .Values.postgres.url (not .Values.postgres.urlSecret) }}
+  {{- if and .Values.postgres.url (not .Values.postgres.urlSecret.name) }}
   {{- if .Values.postgres.connection_parameters }}
   postgres_url: {{ printf "%s?%s" .Values.postgres.url .Values.postgres.connection_parameters | b64enc | quote }}
-  {{- else -}}
+  {{- else }}
   postgres_url: {{ .Values.postgres.url | b64enc | quote }}
   {{- end }}
+  {{- else if and .Values.postgres.host .Values.postgres.port .Values.postgres.database (not .Values.postgres.urlSecret.name) }}
+  {{- $baseUrl := printf "jdbc:postgresql://%s:%v/%s" .Values.postgres.host .Values.postgres.port .Values.postgres.database }}
+  {{- if .Values.postgres.connection_parameters }}
+  postgres_url: {{ printf "%s?%s" $baseUrl .Values.postgres.connection_parameters | b64enc | quote }}
+  {{- else }}
+  postgres_url: {{ $baseUrl | b64enc | quote }}
   {{- end }}
-  {{- if and .Values.postgres.user (not .Values.postgres.userSecret) }}
+  {{- end }}
+  {{- if and .Values.postgres.user (not .Values.postgres.userSecret.name) }}
   postgresql_user: {{ .Values.postgres.user | b64enc | quote }}
   {{- end }}
-  {{- if and .Values.postgres.password (not .Values.postgres.passwordSecret) }}
+  {{- if and .Values.postgres.password (not .Values.postgres.passwordSecret.name) }}
   postgresql_password: {{ .Values.postgres.password | b64enc | quote }}
   {{- end }}
   managementportal_frontend_client_secret: {{ .Values.managementportal.frontend_client_secret | b64enc | quote }}

--- a/charts/management-portal/values.yaml
+++ b/charts/management-portal/values.yaml
@@ -244,6 +244,18 @@ networkpolicy:
       podSelector:
         matchLabels:
           app.kubernetes.io/name: '{{ .Values.postgres.host | default "radar-cloudnative-postgresql-cluster" | trunc 63 | trimSuffix "-" }}'
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: '{{ .Release.Namespace }}'
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: hydra
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: '{{ .Release.Namespace }}'
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: kratos
   - to:
     - namespaceSelector:
         matchLabels:
@@ -275,22 +287,28 @@ postgres:
   database:
   # -- Kubernetes secret containing the database JDBC Connection url
   # (disables use of 'host', 'port' and 'database' values).
+  # Set to empty/null to use chart's own secret created from postgres.url value
+  # Otherwise e.g. name: radar-cloudnative-postgresql-managementportal
   urlSecret:
-    name: radar-cloudnative-postgresql-managementportal
+    name:
     key: jdbc-uri
   # -- database user
   user:
   # -- Kubernetes secret containing the database username
   # (disables use of 'user' value).
+  # Set to empty/null to use chart's own secret created from postgres.user value
+  # Otherwise e.g. name: radar-cloudnative-postgresql-managementportal
   userSecret:
-    name: radar-cloudnative-postgresql-managementportal
+    name:
     key: username
   # -- password of the database user
   password:
   # -- Kubernetes secret containing the database password
   # (disables use of 'password' value).
+  # Set to empty/null to use chart's own secret created from postgres.password value
+  # Otherwise e.g. name: radar-cloudnative-postgresql-managementportal
   passwordSecret:
-    name: radar-cloudnative-postgresql-managementportal
+    name:
     key: password
 
   # -- Additional JDBC connection parameters e.g. sslmode=verify-full.
@@ -314,22 +332,36 @@ catalogue_server: catalog-server
 
 # Settings pertaining to the identity provider (IDP)
 identity_server:
+  # -- Whether the IDP is the MP's internal IDP
+  internal: true
+
+  # Set the following values if the IDP is external to the cluster (i.e. Ory Kratos)
+
+  # -- The publicly accessible server URL for the IDP; needed when deviating from http(s)://server_name/kratos
+  public_url: http://radar-kratos-public
+  # -- The admin server URL for the IDP used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides
+  admin_url: http://radar-kratos-admin
+  # -- The user activation flow type to use for Management Portal (e.g., recovery, verification)
+  user_activation_flow_type: "verification"
+  # -- The user activation method to use for Management Portal (e.g., link, code)
+  user_activation_method: "link"
   # -- The admin email to link to the admin service account. This account should only be used to set up admin-users
   admin_email: admin@example.com
-  # -- The publicly accessible server URL for the IDP; needed when deviating from http(s)://server_name/kratos
-  server_url:
-  # -- The admin server URL for the IDP used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides
-  server_admin_url: http://radar-kratos-admin
-  # -- The publicly accessible login URL for the IDP; needed when deviating from http(s)://server_name/kratos-ui
-  login_url:
 
 authserver:
+  # -- Whether the authserver is the MP's internal authserver
+  internal: true
+
+  # Set the following values if the authserver is external to the cluster (i.e. Ory Hydra)
+
   # -- The publicly accessible server URL for the authserver; needed when deviating from http(s)://server_name/auth
-  server_url: http://radar-hydra:4444
+  token_url: http://radar-hydra-public:4444/oauth2/token
   # -- The admin server URL for the authserver used for service-to-service requests. Only needs to be accessible from inside the cluster where the managementportal resides
-  server_admin_url: http://radar-hydra:4445
+  admin_url: http://radar-hydra-admin:4445
   # -- The publicly accessible login URL for the authserver; needed when deviating from http(s)://server_name/auth/login
-  login_url: http://localhost:4444
+  auth_url: '{{ .Values.advertised_protocol }}://{{ .Values.server_name }}/hydra/oauth2/auth'
+  # -- The JWKS URL for the authserver; needed when deviating from http(s)://server_name/auth/jwks
+  jwks_url: http://radar-hydra-admin:4445/admin/keys/hydra.jwt.access-token
 
 managementportal:
   # -- set to true, if automatic source-type import from catalogue server should be enabled
@@ -346,6 +378,10 @@ managementportal:
   frontend_client_secret: xxx
   # -- Admin password of the default admin user created by the system
   common_admin_password: xxx
+   # -- The file where the OAuth2 client details are stored
+  oauth_clients_file: /secrets/oauth_client_details.csv
+  # -- Base URL managementportal calls from inside the application container
+  base_url: ''
 
 # Configurations of the SMTP server to send activation emails from Management Portal
 smtp:
@@ -608,7 +644,7 @@ oauth_clients:
     access_token_validity: 900
     refresh_token_validity: 78000
     redirect_uri:
-      - http://dashboard.localhost/login/generic_oauth
+      - '{{ .Values.advertised_protocol }}://dashboard.{{ .Values.server_name }}/login/generic_oauth'
     autoapprove:
       - USER.READ
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of maintainers might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
- Moved management-portal changes from #4303 to this PR
- Added Ory Hydra / Kratos integration (auth-code login flow, new login endpoint, and subject-creation webhook).
- Transitioned authentication and authorization to a profile-based setup via `identity_server.internal` and `authserver.internal` vars
- Based on new MP release https://github.com/RADAR-base/ManagementPortal/pull/1080
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
