### PR TITLE
[radar-rest-sources-backend] Drop usesPkce from rest source auth's client configs,

### DIFF
--- a/charts/radar-rest-sources-backend/Chart.yaml
+++ b/charts/radar-rest-sources-backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "4.4.15"
 description: A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 name: radar-rest-sources-backend
-version: 1.5.10
+version: 1.5.11
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-rest-sources-backend

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -111,12 +111,10 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 | restSourceClients.fitbit.clientId | string | `nil` | FitBit client id |
 | restSourceClients.fitbit.clientSecret | string | `nil` | FitBit client secret |
 | restSourceClients.fitbit.scope | string | `"activity heartrate sleep profile"` | List of scopes of the data that should be collected from Fitbit. For details, please refer to https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/#Scopes |
-| restSourceClients.fitbit.usesPkce | bool | `false` | Whether this client uses PKCE for authorization |
 | restSourceClients.fitbit.oauthVersion | string | `"oauth2"` | OAuth version to use: "oauth2" for standard OAuth2 flow |
 | restSourceClients.garmin.enable | bool | `false` | set to true, if Garmin client should be used |
 | restSourceClients.garmin.sourceType | string | `"Garmin"` | Type of the data sources |
 | restSourceClients.garmin.oauthVersion | string | `"oauth2"` | OAuth version to use: "oauth2" for PKCE flow, "oauth1" for legacy flow. OAuth1 will be retired on 12/31/2026. |
-| restSourceClients.garmin.usesPkce | bool | `true` | Whether this client uses PKCE (must be true for Garmin OAuth2) |
 | restSourceClients.garmin.preAuthorizationEndpoint | string | `"https://connectapi.garmin.com/oauth-service/oauth/request_token"` | Pre authorization endpoint to get request token (OAuth1 only, ignored when oauthVersion is oauth2) |
 | restSourceClients.garmin.authorizationEndpoint | string | `"https://connect.garmin.com/oauth2Confirm"` | Authorization endpoint for Garmin authentication. For OAuth2: oauth2Confirm, for OAuth1: oauthConfirm |
 | restSourceClients.garmin.tokenEndpoint | string | `"https://diauth.garmin.com/di-oauth2-service/oauth/token"` | Token endpoint to request access-token from Garmin. For OAuth2: di-oauth2-service, for OAuth1: oauth-service |
@@ -132,5 +130,4 @@ A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 | restSourceClients.oura.clientId | string | `"Oura-clientid"` | Oura client id |
 | restSourceClients.oura.clientSecret | string | `"Oura-clientsecret"` | Oura client secret |
 | restSourceClients.oura.scope | string | `"daily session heartrate workout tag personal email spo2 ring_configuration"` | List of scopes of the data that should be collected from Oura. For details, please refer to https://cloud.ouraring.com/docs/authentication |
-| restSourceClients.oura.usesPkce | bool | `true` | Whether this client uses PKCE for authorization |
 | restSourceClients.oura.oauthVersion | string | `"oauth2"` | OAuth version to use: "oauth2" for standard OAuth2 flow |

--- a/charts/radar-rest-sources-backend/README.md
+++ b/charts/radar-rest-sources-backend/README.md
@@ -3,7 +3,7 @@
 # radar-rest-sources-backend
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-rest-sources-backend)](https://artifacthub.io/packages/helm/radar-base/radar-rest-sources-backend)
 
-![Version: 1.5.10](https://img.shields.io/badge/Version-1.5.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.15](https://img.shields.io/badge/AppVersion-4.4.15-informational?style=flat-square)
+![Version: 1.5.11](https://img.shields.io/badge/Version-1.5.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.4.15](https://img.shields.io/badge/AppVersion-4.4.15-informational?style=flat-square)
 
 A Helm chart for the backend application of RADAR-base Rest Sources Authorizer
 

--- a/charts/radar-rest-sources-backend/values.yaml
+++ b/charts/radar-rest-sources-backend/values.yaml
@@ -311,8 +311,6 @@ restSourceClients:
     clientSecret:
     # -- List of scopes of the data that should be collected from Fitbit. For details, please refer to https://dev.fitbit.com/build/reference/web-api/developer-guide/application-design/#Scopes
     scope: activity heartrate sleep profile
-    # -- Whether this client uses PKCE for authorization
-    usesPkce: false
     # -- OAuth version to use: "oauth2" for standard OAuth2 flow
     oauthVersion: oauth2
 
@@ -323,8 +321,6 @@ restSourceClients:
     sourceType: Garmin
     # -- OAuth version to use: "oauth2" for PKCE flow, "oauth1" for legacy flow. OAuth1 will be retired on 12/31/2026.
     oauthVersion: oauth2
-    # -- Whether this client uses PKCE (must be true for Garmin OAuth2)
-    usesPkce: true
     # -- Pre authorization endpoint to get request token (OAuth1 only, ignored when oauthVersion is oauth2)
     preAuthorizationEndpoint: https://connectapi.garmin.com/oauth-service/oauth/request_token
     # -- Authorization endpoint for Garmin authentication. For OAuth2: oauth2Confirm, for OAuth1: oauthConfirm
@@ -356,7 +352,5 @@ restSourceClients:
     clientSecret: Oura-clientsecret
     # -- List of scopes of the data that should be collected from Oura. For details, please refer to https://cloud.ouraring.com/docs/authentication
     scope: daily session heartrate workout tag personal email spo2 ring_configuration
-    # -- Whether this client uses PKCE for authorization
-    usesPkce: true
     # -- OAuth version to use: "oauth2" for standard OAuth2 flow
     oauthVersion: oauth2


### PR DESCRIPTION
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])

Removing the configs which will be dervied at runtime based on the client,