### PR TITLE
[radar-hydra] Update oauth client values

### DIFF
--- a/charts/radar-hydra/Chart.yaml
+++ b/charts/radar-hydra/Chart.yaml
@@ -6,7 +6,7 @@ home: https://radar-base.org
 icon: http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-hydra
-version: 0.3.0
+version: 0.3.1
 maintainers:
   - email: pim@thehyve.nl
     name: Pim van Nierop

--- a/charts/radar-hydra/README.md
+++ b/charts/radar-hydra/README.md
@@ -3,7 +3,7 @@
 # radar-hydra
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-hydra)](https://artifacthub.io/packages/helm/radar-base/radar-hydra)
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
 
 A ORY Hydra Helm chart for RADAR-base. ORY Hydra is a cloud native Identity and User Management system.
 
@@ -71,12 +71,16 @@ Consult the [documentation](https://artifacthub.io/packages/helm/ory/hydra) of t
 | oauth_clients.pRMT.scope[6] | string | `"SUBJECT.READ"` |  |
 | oauth_clients.pRMT.scope[7] | string | `"SUBJECT.UPDATE"` |  |
 | oauth_clients.pRMT.scope[8] | string | `"USER.READ"` |  |
+| oauth_clients.pRMT.scope[9] | string | `"offline_access"` |  |
 | oauth_clients.pRMT.grantTypes[0] | string | `"refresh_token"` |  |
 | oauth_clients.pRMT.grantTypes[1] | string | `"authorization_code"` |  |
 | oauth_clients.pRMT.access_token_validity | int | `43200` |  |
 | oauth_clients.pRMT.refresh_token_validity | int | `7948800` |  |
 | oauth_clients.pRMT.additional_information | string | `"{\"dynamic_registration\": true}"` |  |
-| oauth_clients.pRMT.tokenEndpointAuthMethod | string | `"client_secret_post"` |  |
+| oauth_clients.pRMT.tokenEndpointAuthMethod | string | `"client_secret_basic"` |  |
+| oauth_clients.pRMT.redirectUris[0] | string | `"{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/study/connect/prmt"` |  |
+| oauth_clients.pRMT.redirectUris[1] | string | `"org.radarbase.prmt:/"` |  |
+| oauth_clients.pRMT.redirectUris[2] | string | `"org.radarbase.prmt://login"` |  |
 | oauth_clients.aRMT.enable | bool | `false` |  |
 | oauth_clients.aRMT.audience[0] | string | `"res_gateway"` |  |
 | oauth_clients.aRMT.audience[1] | string | `"res_ManagementPortal"` |  |
@@ -94,13 +98,16 @@ Consult the [documentation](https://artifacthub.io/packages/helm/ory/hydra) of t
 | oauth_clients.aRMT.scope[7] | string | `"SUBJECT.READ"` |  |
 | oauth_clients.aRMT.scope[8] | string | `"SUBJECT.UPDATE"` |  |
 | oauth_clients.aRMT.scope[9] | string | `"USER.READ"` |  |
+| oauth_clients.aRMT.scope[10] | string | `"offline_access"` |  |
 | oauth_clients.aRMT.grantTypes[0] | string | `"refresh_token"` |  |
 | oauth_clients.aRMT.grantTypes[1] | string | `"authorization_code"` |  |
 | oauth_clients.aRMT.access_token_validity | int | `43200` |  |
 | oauth_clients.aRMT.refresh_token_validity | int | `7948800` |  |
 | oauth_clients.aRMT.additional_information | string | `"{\"dynamic_registration\": true}"` |  |
-| oauth_clients.aRMT.tokenEndpointAuthMethod | string | `"client_secret_post"` |  |
-| oauth_clients.aRMT.redirectUris[0] | string | `"{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/managementportal/api/redirect/login"` |  |
+| oauth_clients.aRMT.tokenEndpointAuthMethod | string | `"none"` |  |
+| oauth_clients.aRMT.redirectUris[0] | string | `"{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/study/connect/armt"` |  |
+| oauth_clients.aRMT.redirectUris[1] | string | `"org.phidatalab.radar-armt:/"` |  |
+| oauth_clients.aRMT.redirectUris[2] | string | `"org.phidatalab.radar_armt:/"` |  |
 | oauth_clients.SEP.enable | bool | `false` |  |
 | oauth_clients.SEP.audience[0] | string | `"res_gateway"` |  |
 | oauth_clients.SEP.audience[1] | string | `"res_ManagementPortal"` |  |
@@ -121,7 +128,7 @@ Consult the [documentation](https://artifacthub.io/packages/helm/ory/hydra) of t
 | oauth_clients.SEP.access_token_validity | int | `43200` |  |
 | oauth_clients.SEP.refresh_token_validity | int | `7948800` |  |
 | oauth_clients.SEP.additional_information | string | `"{\"dynamic_registration\": true}"` |  |
-| oauth_clients.SEP.redirectUris[0] | string | `"{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/managementportal/api/redirect/login"` |  |
+| oauth_clients.SEP.redirectUris[0] | string | `"{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/study/connect/sep"` |  |
 | oauth_clients.THINC-IT.enable | bool | `false` |  |
 | oauth_clients.THINC-IT.audience[0] | string | `"res_gateway"` |  |
 | oauth_clients.THINC-IT.audience[1] | string | `"res_ManagementPortal"` |  |
@@ -200,6 +207,7 @@ Consult the [documentation](https://artifacthub.io/packages/helm/ory/hydra) of t
 | oauth_clients.radar_rest_sources_authorizer.scope[3] | string | `"SUBJECT.UPDATE"` |  |
 | oauth_clients.radar_rest_sources_authorizer.scope[4] | string | `"SUBJECT.CREATE"` |  |
 | oauth_clients.radar_rest_sources_authorizer.grantTypes[0] | string | `"authorization_code"` |  |
+| oauth_clients.radar_rest_sources_authorizer.grantTypes[1] | string | `"refresh_token"` |  |
 | oauth_clients.radar_rest_sources_authorizer.access_token_validity | int | `900` |  |
 | oauth_clients.radar_rest_sources_authorizer.redirectUris[0] | string | `"{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/rest-sources/authorizer/login"` |  |
 | oauth_clients.radar_rest_sources_authorizer.tokenEndpointAuthMethod | string | `"client_secret_post"` |  |
@@ -211,6 +219,14 @@ Consult the [documentation](https://artifacthub.io/packages/helm/ory/hydra) of t
 | oauth_clients.radar_fitbit_connector.grantTypes[0] | string | `"client_credentials"` |  |
 | oauth_clients.radar_fitbit_connector.access_token_validity | int | `900` |  |
 | oauth_clients.radar_fitbit_connector.tokenEndpointAuthMethod | string | `"client_secret_post"` |  |
+| oauth_clients.radar_oura_connector.enable | bool | `false` |  |
+| oauth_clients.radar_oura_connector.audience[0] | string | `"res_restAuthorizer"` |  |
+| oauth_clients.radar_oura_connector.client_secret | string | `""` |  |
+| oauth_clients.radar_oura_connector.scope[0] | string | `"SUBJECT.READ"` |  |
+| oauth_clients.radar_oura_connector.scope[1] | string | `"MEASUREMENT.CREATE"` |  |
+| oauth_clients.radar_oura_connector.grantTypes[0] | string | `"client_credentials"` |  |
+| oauth_clients.radar_oura_connector.access_token_validity | int | `900` |  |
+| oauth_clients.radar_oura_connector.tokenEndpointAuthMethod | string | `"client_secret_post"` |  |
 | oauth_clients.radar_appconfig.enable | bool | `false` |  |
 | oauth_clients.radar_appconfig.audience[0] | string | `"res_ManagementPortal"` |  |
 | oauth_clients.radar_appconfig.audience[1] | string | `"res_appconfig"` |  |

--- a/charts/radar-hydra/values.yaml
+++ b/charts/radar-hydra/values.yaml
@@ -136,13 +136,18 @@ oauth_clients:
       - SUBJECT.READ
       - SUBJECT.UPDATE
       - USER.READ
+      - offline_access
     grantTypes:
       - refresh_token
       - authorization_code
     access_token_validity: 43200
     refresh_token_validity: 7948800
     additional_information: '{"dynamic_registration": true}'
-    tokenEndpointAuthMethod: client_secret_post
+    tokenEndpointAuthMethod: client_secret_basic
+    redirectUris:
+      - '{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/study/connect/prmt'
+      - 'org.radarbase.prmt:/'
+      - 'org.radarbase.prmt://login'
 
   aRMT:
     enable: false
@@ -164,15 +169,18 @@ oauth_clients:
       - SUBJECT.READ
       - SUBJECT.UPDATE
       - USER.READ
+      - offline_access
     grantTypes:
       - refresh_token
       - authorization_code
     access_token_validity: 43200
     refresh_token_validity: 7948800
     additional_information: '{"dynamic_registration": true}'
-    tokenEndpointAuthMethod: client_secret_post
+    tokenEndpointAuthMethod: none
     redirectUris:
-      - '{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/managementportal/api/redirect/login'
+      - '{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/study/connect/armt'
+      - 'org.phidatalab.radar-armt:/'
+      - 'org.phidatalab.radar_armt:/'
 
   SEP:
     enable: false
@@ -199,7 +207,7 @@ oauth_clients:
     refresh_token_validity: 7948800
     additional_information: '{"dynamic_registration": true}'
     redirectUris:
-      - '{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/managementportal/api/redirect/login'
+      - '{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/study/connect/sep'
 
   THINC-IT:
     enable: false
@@ -315,12 +323,26 @@ oauth_clients:
       - SUBJECT.CREATE
     grantTypes:
       - authorization_code
+      - refresh_token
     access_token_validity: 900
     redirectUris:
       - '{{ .Values.hydra.advertised_protocol }}://{{ .Values.hydra.server_name }}/rest-sources/authorizer/login'
     tokenEndpointAuthMethod: client_secret_post
 
   radar_fitbit_connector:
+    enable: false
+    audience:
+      - res_restAuthorizer
+    client_secret: ""
+    scope:
+      - SUBJECT.READ
+      - MEASUREMENT.CREATE
+    grantTypes:
+      - client_credentials
+    access_token_validity: 900
+    tokenEndpointAuthMethod: client_secret_post
+
+  radar_oura_connector:
     enable: false
     audience:
       - res_restAuthorizer


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of maintainers might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
- Update `oauth_client` values of the default RADAR clients
- This includes updating the redirect_uris to support SEP and app logins
- Also adds the `radar_oura_connector` as a default cilent

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
