### PR TITLE
[radar-push-endpoint] Chart fixes for Radar Pushendpoint 

### DIFF
--- a/charts/radar-push-endpoint/Chart.yaml
+++ b/charts/radar-push-endpoint/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "0.4.0"
 description: A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming data from Push or Subscription based WEB APIs. It performs authentication, authorization and content validation. For more details of the configurations, see https://github.com/RADAR-base/RADAR-PushEndpoint.
 name: radar-push-endpoint
-version: 0.6.7
+version: 0.6.8
 icon: "http://radar-base.org/wp-content/uploads/2022/09/Logo_RADAR-Base-RGB.png"
 sources:
 - https://github.com/RADAR-base/radar-helm-charts/tree/main/charts/radar-push-endpoint

--- a/charts/radar-push-endpoint/README.md
+++ b/charts/radar-push-endpoint/README.md
@@ -3,7 +3,7 @@
 # radar-push-endpoint
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/radar-push-endpoint)](https://artifacthub.io/packages/helm/radar-base/radar-push-endpoint)
 
-![Version: 0.6.7](https://img.shields.io/badge/Version-0.6.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.6.8](https://img.shields.io/badge/Version-0.6.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 A Helm chart for RADAR-base Push Endpoint. REST Gateway to Kafka, for incoming data from Push or Subscription based WEB APIs. It performs authentication, authorization and content validation. For more details of the configurations, see https://github.com/RADAR-base/RADAR-PushEndpoint.
 

--- a/charts/radar-push-endpoint/templates/_helpers.tpl
+++ b/charts/radar-push-endpoint/templates/_helpers.tpl
@@ -13,6 +13,7 @@ Return the proper image name
 {{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global "chart" .Chart ) }}
 {{- end -}}
 
+{{/*
 Return the proper exporter image name
 */}}
 {{- define "radar-push-endpoint.image-exporter" -}}

--- a/charts/radar-push-endpoint/templates/deployment.yaml
+++ b/charts/radar-push-endpoint/templates/deployment.yaml
@@ -52,7 +52,8 @@ spec:
             - name: "CONFIG_YML"
               value: "/etc/radar-push-endpoint/config.yml"
           ports:
-          - containerPort: 5556
+          - name: metrics
+            containerPort: 5556
             protocol: TCP
           resources:
             requests:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of maintainers might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Two small chart fixes in radar-push-endpoint:                                                                                                                                                                                                                                                                                                                       
  - deployment.yaml: the JMX exporter container exposed `containerPort: 5556` with no name, but the service forwards to `targetPort: metrics` by name.  Added `name: metrics` so the named-port chain resolves correctly.                                                                                                                
  - _helpers.tpl: the "Return the proper exporter image name" comment block was missing its `{{/*`


**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [<name_of_the_chart>])
