### PR TITLE
fix: fitbit timezone property name

### DIFF
--- a/charts/radar-fitbit-connector/templates/configmap-properties.yaml
+++ b/charts/radar-fitbit-connector/templates/configmap-properties.yaml
@@ -38,8 +38,8 @@ data:
     fitbit.sleep.stages.topic={{ .Values.routes.sleepStages.topic }}
     fitbit.sleep.classic.enabled={{ .Values.routes.sleepClassic.enabled }}
     fitbit.sleep.classic.topic={{ .Values.routes.sleepClassic.topic }}
-    fitbit.timezone.enabled={{ .Values.routes.timezone.enabled }}
-    fitbit.timezone.topic={{ .Values.routes.timezone.topic }}
+    fitbit.time.zone.enabled={{ .Values.routes.timezone.enabled }}
+    fitbit.time.zone.topic={{ .Values.routes.timezone.topic }}
     fitbit.activity.log.enabled={{ .Values.routes.activityLog.enabled }}
     fitbit.activity.log.topic={{ .Values.routes.activityLog.topic }}
     fitbit.intraday.calories.enabled={{ .Values.routes.intradayCalories.enabled }}


### PR DESCRIPTION
# Background
The properties for FB timezone are named incorrectly. In rest source connector code:
```
  private static final String FITBIT_TIME_ZONE_TOPIC_CONFIG = "fitbit.time.zone.topic";
  ...
  private static final String FITBIT_TIME_ZONE_ENABLED_CONFIG = "fitbit.time.zone.enabled";
```

# Fix
This PR renames the properties to match the FBC codebase (_fitbit.time.zone.topic_ and fitbit.time.zone.enabled_)