### PR TITLE
fix(ci): add missing dependency repos to helm-publish workflow

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -33,6 +33,8 @@ jobs:
           helm repo add dysnix https://dysnix.github.io/charts/
           helm repo add stable https://charts.helm.sh/stable
           helm repo add cp-radar https://radar-base.github.io/cp-helm-charts
+          helm repo add headlamp https://kubernetes-sigs.github.io/headlamp/
+          helm repo add kubecost https://kubecost.github.io/cost-analyzer/
           helm repo update
 
       - name: Run chart-releaser


### PR DESCRIPTION
## Problem

`Release Helm Charts` has failed on every push to `main` since #13512 merged — no chart has published since 2026-07-27:

Packaging chart 'external/headlamp' Error: no repository definition for https://kubernetes-sigs.github.io/headlamp/

`chart-releaser` resolves `Chart.yaml` dependencies through helm, so the dependency repo must be defined on the runner — vendoring the `.tgz` isn't enough.

Since headlamp is packaged before kubecost, this blocked kubecost (#7214) from publishing too.

## Fix

Adds the two missing dependency repos to the `Add Helm repos` step. kubecost had the same latent gap.

Re-running the failed jobs won't help — they replay the old workflow file, so this has to land on `main`.
